### PR TITLE
Improve non-standard type encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0.rc1](https://github.com/nhairs/python-json-logger/compare/v3.0.1...v3.1.0.rc1) - 2023-05-03
+## [3.1.0.rc2](https://github.com/nhairs/python-json-logger/compare/v3.0.1...v3.1.0.rc1) - 2023-05-03
 
 This splits common funcitonality out to allow supporting other JSON encoders. Although this is a large refactor, backwards compatibility has been maintained.
 
 ### Added
 - `.core` - more details below.
-- Orjson encoder support via `.orjson.OrjsonFormatter`.
-- MsgSpec encoder support via `.msgspec.MsgspecFormatter`.
+- `.defaults` module that provides many functions for handling unsupported types.
+- Orjson encoder support via `.orjson.OrjsonFormatter` with the following additions:
+  - bytes are URL safe base64 encoded.
+  - Exceptions are "pretty printed" using the exception name and message e.g. `"ValueError: bad value passed"`
+  - Enum values use their value, Enum classes now return all values as a list.
+  - Tracebacks are supported
+  - Classes (aka types) are support
+  - Will fallback on `__str__` if available, else `__repr__` if available, else will use `__could_not_encode__`
+- MsgSpec encoder support via `.msgspec.MsgspecFormatter` with the following additions:
+  - Exceptions are "pretty printed" using the exception name and message e.g. `"ValueError: bad value passed"`
+  - Enum classes now return all values as a list.
+  - Tracebacks are supported
+  - Classes (aka types) are support
+  - Will fallback on `__str__` if available, else `__repr__` if available, else will use `__could_not_encode__`
 
 ### Changed
 - `.jsonlogger` has been moved to `.json` with core functionality moved to `.core`.
@@ -21,6 +33,12 @@ This splits common funcitonality out to allow supporting other JSON encoders. Al
   - `style` can now support non-standard arguments by setting `validate` to `False`
   - `validate` allows non-standard `style` arguments or prevents calling `validate` on standard `style` arguments.
   - `default` is ignored.
+- `.json.JsonEncoder` default encodings changed:
+  - bytes are URL safe base64 encoded.
+  - Exception formatting detected using `BaseException` instead of `Exception`. Now "pretty prints" the exception using the exception name and message e.g. `"ValueError: bad value passed"`
+  - Dataclasses are now supported
+  - Enum values now use their value, Enum classes now return all values as a list.
+  - Will fallback on `__str__` if available, else `__repr__` if available, else will use `__could_not_encode__`
 
 ### Deprecated
 - `.jsonlogger` is now `.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This splits common funcitonality out to allow supporting other JSON encoders. Al
   - Tracebacks are supported
   - Classes (aka types) are support
   - Will fallback on `__str__` if available, else `__repr__` if available, else will use `__could_not_encode__`
+  - Note: msgspec only supprts enum values of type `int` or `str` [jcrist/msgspec#680](https://github.com/jcrist/msgspec/issues/680)
 
 ### Changed
 - `.jsonlogger` has been moved to `.json` with core functionality moved to `.core`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0.rc2](https://github.com/nhairs/python-json-logger/compare/v3.0.1...v3.1.0.rc1) - 2023-05-03
+## [3.1.0.rc2](https://github.com/nhairs/python-json-logger/compare/v3.0.1...v3.1.0.rc2) - 2023-05-03
 
 This splits common funcitonality out to allow supporting other JSON encoders. Although this is a large refactor, backwards compatibility has been maintained.
 

--- a/pylintrc
+++ b/pylintrc
@@ -75,8 +75,9 @@ disable=raw-checker-failed,
         # cases. Disable rules that can cause conflicts
         line-too-long,
         # Module docstrings are not required
-        missing-module-docstring
+        missing-module-docstring,
         ## Project Disables
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dev = [
     ## Test
     "pytest",
     "freezegun",
+    "backports.zoneinfo;python_version<'3.9'",
+    "tzdata",
     ## Build
     "build",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-json-logger"
-version = "3.1.0.rc1"
+version = "3.1.0.rc2"
 description = "JSON Log Formatter for the Python Logging Package"
 authors = [
     {name = "Zakaria Zajac", email = "zak@madzak.com"},

--- a/src/pythonjsonlogger/defaults.py
+++ b/src/pythonjsonlogger/defaults.py
@@ -29,10 +29,14 @@ else:
 ### FUNCTIONS
 ### ============================================================================
 def unknown_default(obj: Any) -> str:
-    if hasattr(obj, "__str__"):
+    try:
         return str(obj)
-    if hasattr(obj, "__repr__"):
+    except Exception:
+        pass
+    try:
         return repr(obj)
+    except Exception:
+        pass
     return "__could_not_encode__"
 
 

--- a/src/pythonjsonlogger/defaults.py
+++ b/src/pythonjsonlogger/defaults.py
@@ -31,11 +31,11 @@ else:
 def unknown_default(obj: Any) -> str:
     try:
         return str(obj)
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         pass
     try:
         return repr(obj)
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         pass
     return "__could_not_encode__"
 

--- a/src/pythonjsonlogger/defaults.py
+++ b/src/pythonjsonlogger/defaults.py
@@ -19,7 +19,7 @@ import uuid
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
 else:
-    from typing_extension import TypeGuard
+    from typing_extensions import TypeGuard
 
 ## Installed
 

--- a/src/pythonjsonlogger/defaults.py
+++ b/src/pythonjsonlogger/defaults.py
@@ -1,0 +1,142 @@
+# pylint: disable=missing-function-docstring
+
+### IMPORTS
+### ============================================================================
+## Future
+from __future__ import annotations
+
+## Standard Library
+import base64
+import dataclasses
+import datetime
+import enum
+import sys
+from types import TracebackType
+from typing import Any
+import traceback
+import uuid
+
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard
+else:
+    from typing_extension import TypeGuard
+
+## Installed
+
+## Application
+
+
+### FUNCTIONS
+### ============================================================================
+def unknown_default(obj: Any) -> str:
+    if hasattr(obj, "__str__"):
+        return str(obj)
+    if hasattr(obj, "__repr__"):
+        return repr(obj)
+    return "__could_not_encode__"
+
+
+## Types
+## -----------------------------------------------------------------------------
+def use_type_default(obj: Any) -> TypeGuard[type]:
+    return isinstance(obj, type)
+
+
+def type_default(obj: type) -> str:
+    return obj.__name__
+
+
+## Dataclasses
+## -----------------------------------------------------------------------------
+def use_dataclass_default(obj: Any) -> bool:
+    return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
+
+
+def dataclass_default(obj) -> dict[str, Any]:
+    return dataclasses.asdict(obj)
+
+
+## Dates and Times
+## -----------------------------------------------------------------------------
+def use_time_default(obj: Any) -> TypeGuard[datetime.time]:
+    return isinstance(obj, datetime.time)
+
+
+def time_default(obj: datetime.time) -> str:
+    return obj.isoformat()
+
+
+def use_date_default(obj: Any) -> TypeGuard[datetime.date]:
+    return isinstance(obj, datetime.date)
+
+
+def date_default(obj: datetime.date) -> str:
+    return obj.isoformat()
+
+
+def use_datetime_default(obj: Any) -> TypeGuard[datetime.datetime]:
+    return isinstance(obj, datetime.datetime)
+
+
+def datetime_default(obj: datetime.datetime) -> str:
+    return obj.isoformat()
+
+
+def use_datetime_any(obj: Any) -> TypeGuard[datetime.time | datetime.date | datetime.datetime]:
+    return isinstance(obj, (datetime.time, datetime.date, datetime.datetime))
+
+
+def datetime_any(obj: datetime.time | datetime.date | datetime.date) -> str:
+    return obj.isoformat()
+
+
+## Exception and Tracebacks
+## -----------------------------------------------------------------------------
+def use_exception_default(obj: Any) -> TypeGuard[BaseException]:
+    return isinstance(obj, BaseException)
+
+
+def exception_default(obj: BaseException) -> str:
+    return f"{obj.__class__.__name__}: {obj}"
+
+
+def use_traceback_default(obj: Any) -> TypeGuard[TracebackType]:
+    return isinstance(obj, TracebackType)
+
+
+def traceback_default(obj: TracebackType) -> str:
+    return "".join(traceback.format_tb(obj)).strip()
+
+
+## Enums
+## -----------------------------------------------------------------------------
+def use_enum_default(obj: Any) -> TypeGuard[enum.Enum | enum.EnumMeta]:
+    return isinstance(obj, (enum.Enum, enum.EnumMeta))
+
+
+def enum_default(obj: enum.Enum | enum.EnumMeta) -> Any | list[Any]:
+    if isinstance(obj, enum.Enum):
+        return obj.value
+    return [e.value for e in obj]  # type: ignore[var-annotated]
+
+
+## UUIDs
+## -----------------------------------------------------------------------------
+def use_uuid_default(obj: Any) -> TypeGuard[uuid.UUID]:
+    return isinstance(obj, uuid.UUID)
+
+
+def uuid_default(obj: uuid.UUID) -> str:
+    return str(obj)
+
+
+## Bytes
+## -----------------------------------------------------------------------------
+def use_bytes_default(obj: Any) -> TypeGuard[bytes | bytearray]:
+    return isinstance(obj, (bytes, bytearray))
+
+
+def bytes_default(obj: bytes | bytearray, url_safe: bool = True) -> str:
+    if url_safe:
+        return base64.urlsafe_b64encode(obj).decode("utf8")
+    return base64.b64encode(obj).decode("utf8")

--- a/src/pythonjsonlogger/msgspec.py
+++ b/src/pythonjsonlogger/msgspec.py
@@ -4,12 +4,29 @@
 from __future__ import annotations
 
 ## Standard Library
+from typing import Any
 
 ## Installed
 import msgspec.json
 
 ## Application
 from . import core
+from . import defaults as d
+
+
+### FUNCTIONS
+### ============================================================================
+def msgspec_default(obj: Any) -> Any:
+    """msgspec default encoder function for non-standard types"""
+    if d.use_exception_default(obj):
+        return d.exception_default(obj)
+    if d.use_traceback_default(obj):
+        return d.traceback_default(obj)
+    if d.use_enum_default(obj):
+        return d.enum_default(obj)
+    if d.use_type_default(obj):
+        return d.type_default(obj)
+    return d.unknown_default(obj)
 
 
 ### CLASSES
@@ -25,7 +42,7 @@ class MsgspecFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = None,
+        json_default: core.OptionalCallableOrStr = msgspec_default,
         **kwargs,
     ) -> None:
         """

--- a/src/pythonjsonlogger/orjson.py
+++ b/src/pythonjsonlogger/orjson.py
@@ -4,12 +4,31 @@
 from __future__ import annotations
 
 ## Standard Library
+from typing import Any
 
 ## Installed
 import orjson
 
 ## Application
 from . import core
+from . import defaults as d
+
+
+### FUNCTIONS
+### ============================================================================
+def orjson_default(obj: Any) -> Any:
+    """orjson default encoder function for non-standard types"""
+    if d.use_exception_default(obj):
+        return d.exception_default(obj)
+    if d.use_traceback_default(obj):
+        return d.traceback_default(obj)
+    if d.use_bytes_default(obj):
+        return d.bytes_default(obj)
+    if d.use_enum_default(obj):
+        return d.enum_default(obj)
+    if d.use_type_default(obj):
+        return d.type_default(obj)
+    return d.unknown_default(obj)
 
 
 ### CLASSES
@@ -25,7 +44,7 @@ class OrjsonFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = None,
+        json_default: core.OptionalCallableOrStr = orjson_default,
         json_indent: bool = False,
         **kwargs,
     ) -> None:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -16,6 +16,11 @@ from types import TracebackType
 from typing import Any, Generator
 import uuid
 
+if sys.version_info >= (3, 9):
+    import zoneinfo
+else:
+    from backports import zoneinfo
+
 ## Installed
 from freezegun import freeze_time
 import pytest
@@ -398,14 +403,20 @@ def test_default_encoder_with_timestamp(env: LoggingEnvironment, class_: type[Ba
     ["obj", "type_", "expected"],
     [
         ("somestring", str, "somestring"),
+        ("some unicode Привет", str, "some unicode Привет"),
         (1234, int, 1234),
         (1234.5, float, 1234.5),
         (False, bool, False),
         (None, type(None), None),
         (b"some-bytes", str, "c29tZS1ieXRlcw=="),
-        (datetime.time(16, 45, 30, 100), str, NO_TEST),
-        (datetime.date.today(), str, NO_TEST),
-        (datetime.datetime.utcnow(), str, NO_TEST),
+        (datetime.time(16, 45, 30, 100), str, "16:45:30.000100"),
+        (datetime.date(2024, 5, 5), str, "2024-05-05"),
+        (datetime.datetime(2024, 5, 5, 16, 45, 30, 100), str, "2024-05-05T16:45:30.000100"),
+        (
+            datetime.datetime(2024, 5, 5, 16, 45, 30, 100, zoneinfo.ZoneInfo("Australia/Sydney")),
+            str,
+            "2024-05-05T16:45:30.000100+10:00",
+        ),
         (
             uuid.UUID("urn:uuid:12345678-1234-5678-1234-567812345678"),
             str,

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -511,25 +511,6 @@ def test_custom_default(env: LoggingEnvironment, class_: type[BaseJsonFormatter]
 
 ## JsonFormatter Specific
 ## -----------------------------------------------------------------------------
-def test_json_default_encoder(env: LoggingEnvironment):
-    env.set_formatter(JsonFormatter())
-
-    msg = {
-        "adate": datetime.datetime(1999, 12, 31, 23, 59),
-        "otherdate": datetime.date(1789, 7, 14),
-        "otherdatetime": datetime.datetime(1789, 7, 14, 23, 59),
-        "otherdatetimeagain": datetime.datetime(1900, 1, 1),
-    }
-    env.logger.info(msg)
-    log_json = env.load_json()
-
-    assert log_json["adate"] == "1999-12-31T23:59:00"
-    assert log_json["otherdate"] == "1789-07-14"
-    assert log_json["otherdatetime"] == "1789-07-14T23:59:00"
-    assert log_json["otherdatetimeagain"] == "1900-01-01T00:00:00"
-    return
-
-
 def test_json_ensure_ascii_true(env: LoggingEnvironment):
     env.set_formatter(JsonFormatter())
     env.logger.info("Привет")

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -461,8 +461,9 @@ def test_common_types_encoded(
             pytest.xfail()
 
     if pythonjsonlogger.MSGSPEC_AVAILABLE and class_ is MsgspecFormatter:
+        # Dataclass: https://github.com/jcrist/msgspec/issues/681
+        # Enum: https://github.com/jcrist/msgspec/issues/680
         if obj is SomeDataclass or (
-            # https://github.com/jcrist/msgspec/issues/680
             isinstance(obj, enum.Enum) and obj in {MultiEnum.BYTES, MultiEnum.NONE, MultiEnum.BOOL}
         ):
             pytest.xfail()

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -91,6 +91,14 @@ class SomeClass:
         return
 
 
+class BrokenClass:
+    def __str__(self) -> str:
+        raise ValueError("hahah sucker")
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
 @dataclass
 class SomeDataclass:
     things: str
@@ -416,6 +424,7 @@ def test_default_encoder_with_timestamp(env: LoggingEnvironment, class_: type[Ba
         (SomeDataclass, str, "SomeDataclass"),
         (SomeClass, str, "SomeClass"),
         (SomeClass(1234), str, NO_TEST),
+        (BrokenClass(), str, "__could_not_encode__"),
         (MultiEnum.NONE, type(None), None),
         (MultiEnum.BOOL, bool, MultiEnum.BOOL.value),
         (MultiEnum.STR, str, MultiEnum.STR.value),

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -457,14 +457,6 @@ def test_common_types_encoded(
     expected: Any,
 ):
     ## Known bad cases
-    if class_ is JsonFormatter:
-        if False:
-            pytest.xfail()
-
-    if pythonjsonlogger.ORJSON_AVAILABLE and class_ is OrjsonFormatter:
-        if False:
-            pytest.xfail()
-
     if pythonjsonlogger.MSGSPEC_AVAILABLE and class_ is MsgspecFormatter:
         # Dataclass: https://github.com/jcrist/msgspec/issues/681
         # Enum: https://github.com/jcrist/msgspec/issues/680

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -462,6 +462,7 @@ def test_common_types_encoded(
 
     if pythonjsonlogger.MSGSPEC_AVAILABLE and class_ is MsgspecFormatter:
         if obj is SomeDataclass or (
+            # https://github.com/jcrist/msgspec/issues/680
             isinstance(obj, enum.Enum) and obj in {MultiEnum.BYTES, MultiEnum.NONE, MultiEnum.BOOL}
         ):
             pytest.xfail()


### PR DESCRIPTION
This PR improves the JSON encoding of non-standard types by introducing and using the `.defaults` module. The `.defaults` module adds helper functions that can test and apply formatting for types not supported by a given encoder.

Please note that in doing so, some outputs of the `JsonFormatter` have changed. That said these changes return more "reasonable" results rather the the original `str(o)` fallback.

For more detailed list of changes to the encoders see the CHANGELOG.

## Test Plan
Have added additional tests and now check for specific output.