### PR TITLE
Move documentation to mkdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ env
 # IDE
 .vscode
 .idea
+
+# generated docs
+site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This splits common funcitonality out to allow supporting other JSON encoders. Al
   - `style` can now support non-standard arguments by setting `validate` to `False`
   - `validate` allows non-standard `style` arguments or prevents calling `validate` on standard `style` arguments.
   - `default` is ignored.
-- `.json.JsonEncoder` default encodings changed:
+- `.json.JsonFormatter` default encodings changed:
   - bytes are URL safe base64 encoded.
   - Exception formatting detected using `BaseException` instead of `Exception`. Now "pretty prints" the exception using the exception name and message e.g. `"ValueError: bad value passed"`
   - Dataclasses are now supported

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+This software includes the following licenced software:
+  - mkdocstrings-python
+    Copyright (c) 2021, Timothée Mazzucotelli
+    Licenced under ISC Licence
+    Source: https://github.com/mkdocstrings/python

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+<!-- [![PyPi](https://img.shields.io/pypi/v/python-json-logger.svg)](https://pypi.python.org/pypi/python-json-logger/)
+[![PyPI - Status](https://img.shields.io/pypi/status/python-json-logger)](https://pypi.python.org/pypi/python-json-logger/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/python-json-logger.svg)](https://github.com/nhairs/python-json-logger) -->
+[![License](https://img.shields.io/github/license/nhairs/python-json-logger.svg)](https://github.com/nhairs/python-json-logger)
 ![Build Status](https://github.com/nhairs/python-json-logger/actions/workflows/test-suite.yml/badge.svg)
-[![License](https://img.shields.io/pypi/l/python-json-logger.svg)](https://pypi.python.org/pypi/python-json-logger/)
-[![Version](https://img.shields.io/pypi/v/python-json-logger.svg)](https://pypi.python.org/pypi/python-json-logger/)
-
+#
 # Python JSON Logger
 
 This library is provided to allow standard python logging to output log data as json objects. With JSON we can make our logs more readable by machines and we can stop writing custom parsers for syslog type records.
@@ -13,203 +15,12 @@ This repository is a maintained fork of [madzak/python-json-logger](https://gith
 
 [**Changelog**](https://github.com/nhairs/python-json-logger/blob/main/CHANGELOG.md)
 
-## Installation
+## Documentation
 
-Note: All versions of this fork use version `>=3.0.0` - to use pre-fork versions use `python-json-logger<3.0.0`.
-
-### Install via pip
-
-Until the PEP 541 request is complete you will need to install directly from github.
-
-#### Install from GitHub
-
-To install from releases:
-
-```shell
-# e.g. 3.0.0 wheel
-pip install 'python-json-logger@https://github.com/nhairs/python-json-logger/releases/download/v3.0.0/python_json_logger-3.0.0-py3-none-any.whl'
-```
-
-To install from head:
-
-```shell
-pip install 'python-json-logger@git+https://github.com/nhairs/python-json-logger.git'
-```
-
-To install a specific version from a tag:
-
-```shell
-# Last released version before forking
-pip install 'python-json-logger@git+https://github.com/nhairs/python-json-logger.git@v2.0.7'
-```
-
-#### Install from Source
-
-```shell
-git clone https://github.com/nhairs/python-json-logger.git
-cd python-json-logger
-pip install -e .
-```
-
-## Usage
-
-Python JSON Logger provides `logging.Formatter`s that encode the logged message into JSON. Although a variety of JSON encoders are supported, in the following examples we will use the `pythonjsonlogger.json.JsonFormatter` which uses the the `json` module from the standard library.
-
-### Integrating with Python's logging framework
-
-To produce JSON output, attach the formatter to a logging handler:
-
-```python
-    import logging
-    from pythonjsonlogger.json import JsonFormatter
-
-    logger = logging.getLogger()
-
-    logHandler = logging.StreamHandler()
-    formatter = JsonFormatter()
-    logHandler.setFormatter(formatter)
-    logger.addHandler(logHandler)
-```
-
-### Output fields
-
-You can control the logged fields by setting the `fmt` argument when creating the formatter. By default formatters will follow the same `style` of `fmt` as the `logging` module: `%`, `$`, and `{`. All [`LogRecord` attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) can be output using their name.
-
-```python
-formatter = JsonFormatter("{message}{asctime}{exc_info}", style="{")
-```
-
-You can also add extra fields to your json output by specifying a dict in place of message, as well as by specifying an `extra={}` argument.
-
-Contents of these dictionaries will be added at the root level of the entry and may override basic fields.
-
-You can also use the `add_fields` method to add to or generally normalize the set of default set of fields, it is called for every log event. For example, to unify default fields with those provided by [structlog](http://www.structlog.org/) you could do something like this:
-
-```python
-class CustomJsonFormatter(JsonFormatter):
-    def add_fields(self, log_record, record, message_dict):
-        super().add_fields(log_record, record, message_dict)
-        if not log_record.get('timestamp'):
-            # this doesn't use record.created, so it is slightly off
-            now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-            log_record['timestamp'] = now
-        if log_record.get('level'):
-            log_record['level'] = log_record['level'].upper()
-        else:
-            log_record['level'] = record.levelname
-        return
-
-formatter = CustomJsonFormatter('%(timestamp)s %(level)s %(name)s %(message)s')
-```
-
-Items added to the log record will be included in *every* log message, no matter what the format requires.
-
-You can also override the `process_log_record` method to modify fields before they are serialized to JSON.
-
-```python
-class SillyFormatter(JsonFormatter):
-    def process_log_record(log_record):
-        new_record = {k[::-1]: v for k, v in log_record.items()}
-        return new_record
-```
-
-#### Supporting custom styles
-
-It is possible to support custom `style`s by setting `validate=False` and overriding the `parse` method.
-
-For example:
-
-```python
-class CommaSupport(JsonFormatter):
-    def parse(self) -> list[str]:
-        if isinstance(self._style, str) and self._style == ",":
-            return self._fmt.split(",")
-        return super().parse()
-
-formatter = CommaSupport("message,asctime", style=",", validate=False)
-```
-
-### Custom object serialization
-
-Most formatters support `json_default` which is used to control how objects are serialized.
-
-For custom handling of object serialization you can specify default json object translator or provide a custom encoder
-
-```python
-def my_default(obj):
-    if isinstance(obj, MyClass):
-        return {"special": obj.special}
-
-formatter = JsonFormatter(json_default=my_default)
-```
-
-### Using a Config File
-
-To use the module with a config file using the [`fileConfig` function](https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig), use the class `pythonjsonlogger.json.JsonFormatter`. Here is a sample config file.
-
-```ini
-[loggers]
-keys = root,custom
-
-[logger_root]
-handlers =
-
-[logger_custom]
-level = INFO
-handlers = custom
-qualname = custom
-
-[handlers]
-keys = custom
-
-[handler_custom]
-class = StreamHandler
-level = INFO
-formatter = json
-args = (sys.stdout,)
-
-[formatters]
-keys = json
-
-[formatter_json]
-format = %(message)s
-class = pythonjsonlogger.jsonlogger.JsonFormatter
-```
-
-### Alternate JSON Encoders
-
-The following JSON encoders are also supported:
-
-- [orjson](https://github.com/ijl/orjson) - `pythonjsonlogger.orjon.OrjsonFormatter`
-- [msgspec](https://github.com/jcrist/msgspec) - `pythonjsonlogger.msgspec.MsgspecFormatter`
-
-## Example Output
-
-Sample JSON with a full formatter (basically the log message from the unit test). Every log message will appear on 1 line like a typical logger.
-
-```json
-{
-    "threadName": "MainThread",
-    "name": "root",
-    "thread": 140735202359648,
-    "created": 1336281068.506248,
-    "process": 41937,
-    "processName": "MainProcess",
-    "relativeCreated": 9.100914001464844,
-    "module": "tests",
-    "funcName": "testFormatKeys",
-    "levelno": 20,
-    "msecs": 506.24799728393555,
-    "pathname": "tests/tests.py",
-    "lineno": 60,
-    "asctime": "12-05-05 22:11:08,506248",
-    "message": "testing logging format",
-    "filename": "tests.py",
-    "levelname": "INFO",
-    "special": "value",
-    "run": 12
-}
-```
+- [Documentation](https://nhairs.github.io/python-json-logger/latest/)
+- [Quickstart Guide](https://nhairs.github.io/python-json-logger/latest/quickstart/)
+- [Change Log](https://nhairs.github.io/python-json-logger/latest/changelog/)
+- [Contributing](https://nhairs.github.io/python-json-logger/latest/contributing/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 #
 # Python JSON Logger
 
-This library is provided to allow standard python logging to output log data as json objects. With JSON we can make our logs more readable by machines and we can stop writing custom parsers for syslog type records.
+Python JSON Logger enables you produce JSON logs when using Python's `logging` package.
+
+JSON logs are machine readable allowing for much easier parsing and ingestion into log aggregation tools.
 
 
 ### 🚨 Important 🚨
 
 This repository is a maintained fork of [madzak/python-json-logger](https://github.com/madzak/python-json-logger) pending [a PEP 541 request](https://github.com/pypi/support/issues/3607) for the PyPI package.  The future direction of the project is being discussed [here](https://github.com/nhairs/python-json-logger/issues/1).
-
-[**Changelog**](https://github.com/nhairs/python-json-logger/blob/main/CHANGELOG.md)
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,1 @@
-# Security Policy
-
-## Supported Versions
-
-**TLDR**: Security support is provided for Python versions `>=3.7`.
-
-
-## Reporting a Vulnerability
-
-Please report vulnerabilties using GitHub [here](https://github.com/nhairs/python-json-logger/security/advisories/new).
+docs/security.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,4 @@
-# Changelog
+# Change Log
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This splits common funcitonality out to allow supporting other JSON encoders. Although this is a large refactor, backwards compatibility has been maintained.
 
 ### Added
-- `.core` - more details below.
-- `.defaults` module that provides many functions for handling unsupported types.
-- Orjson encoder support via `.orjson.OrjsonFormatter` with the following additions:
+- `pythonjsonlogger.core` - more details below.
+- `pythonjsonlogger.defaults` module that provides many functions for handling unsupported types.
+- Orjson encoder support via `pythonjsonlogger.orjson.OrjsonFormatter` with the following additions:
   - bytes are URL safe base64 encoded.
   - Exceptions are "pretty printed" using the exception name and message e.g. `"ValueError: bad value passed"`
   - Enum values use their value, Enum classes now return all values as a list.
   - Tracebacks are supported
   - Classes (aka types) are support
   - Will fallback on `__str__` if available, else `__repr__` if available, else will use `__could_not_encode__`
-- MsgSpec encoder support via `.msgspec.MsgspecFormatter` with the following additions:
+- MsgSpec encoder support via `pythonjsonlogger.msgspec.MsgspecFormatter` with the following additions:
   - Exceptions are "pretty printed" using the exception name and message e.g. `"ValueError: bad value passed"`
   - Enum classes now return all values as a list.
   - Tracebacks are supported
@@ -27,39 +27,44 @@ This splits common funcitonality out to allow supporting other JSON encoders. Al
   - Note: msgspec only supprts enum values of type `int` or `str` [jcrist/msgspec#680](https://github.com/jcrist/msgspec/issues/680)
 
 ### Changed
-- `.jsonlogger` has been moved to `.json` with core functionality moved to `.core`.
-- `.core.BaseJsonFormatter` properly supports all `logging.Formatter` arguments:
+- `pythonjsonlogger.jsonlogger` has been moved to `pythonjsonlogger.json` with core functionality moved to `pythonjsonlogger.core`.
+- `pythonjsonlogger.core.BaseJsonFormatter` properly supports all `logging.Formatter` arguments:
   - `fmt` is unchanged.
   - `datefmt` is unchanged.
   - `style` can now support non-standard arguments by setting `validate` to `False`
   - `validate` allows non-standard `style` arguments or prevents calling `validate` on standard `style` arguments.
   - `default` is ignored.
-- `.json.JsonFormatter` default encodings changed:
+- `pythonjsonlogger.json.JsonFormatter` default encodings changed:
   - bytes are URL safe base64 encoded.
   - Exception formatting detected using `BaseException` instead of `Exception`. Now "pretty prints" the exception using the exception name and message e.g. `"ValueError: bad value passed"`
   - Dataclasses are now supported
   - Enum values now use their value, Enum classes now return all values as a list.
   - Will fallback on `__str__` if available, else `__repr__` if available, else will use `__could_not_encode__`
-- Renaming fields now preserves order (#7) and ignores missing fields (#6).
+- Renaming fields now preserves order ([#7](https://github.com/nhairs/python-json-logger/issues/7)) and ignores missing fields ([#6](https://github.com/nhairs/python-json-logger/issues/6)).
+- Documentation
+  - Generated documentation using `mkdocs` is stored in `docs/`
+  - Documentation within `README.md` has been moved to `docs/index.md` and `docs/qucikstart.md`.
+  - `CHANGELOG.md` has been moved to `docs/change-log.md`
+  - `SECURITY.md` has been moved and replaced with a symbolic link to `docs/security.md`.
 
 ### Deprecated
-- `.jsonlogger` is now `.json`
-- `.jsonlogger.RESERVED_ATTRS` is now `.core.RESERVED_ATTRS`.
-- `.jsonlogger.merge_record_extra` is now `.core.merge_record_extra`.
+- `pythonjsonlogger.jsonlogger` is now `pythonjsonlogger.json`
+- `pythonjsonlogger.jsonlogger.RESERVED_ATTRS` is now `pythonjsonlogger.core.RESERVED_ATTRS`.
+- `pythonjsonlogger.jsonlogger.merge_record_extra` is now `pythonjsonlogger.core.merge_record_extra`.
 
 ### Removed
 - Python 3.7 support dropped
-- `.jsonlogger.JsonFormatter._str_to_fn` replaced with `.core.str_to_object`.
+- `pythonjsonlogger.jsonlogger.JsonFormatter._str_to_fn` replaced with `pythonjsonlogger.core.str_to_object`.
 
 ## [3.0.1](https://github.com/nhairs/python-json-logger/compare/v3.0.0...v3.0.1) - 2023-04-01
 
 ### Fixes
 
-- Fix spelling of parameter `json_serialiser` -> `json_serializer` (#8) - @juliangilbey
+- Fix spelling of parameter `json_serialiser` -> `json_serializer` ([#8](https://github.com/nhairs/python-json-logger/issues/8)) - @juliangilbey
 
 ## [3.0.0](https://github.com/nhairs/python-json-logger/compare/v2.0.7...v3.0.0) - 2024-03-25
 
-Note: using new major version to seperate changes from this fork and the original (upstream). See #1 for details.
+Note: using new major version to seperate changes from this fork and the original (upstream). See [#1](https://github.com/nhairs/python-json-logger/issues/1) for details.
 
 ### Changes
 - Update supported Python versions - @nhairs

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,10 +47,10 @@ mypy src tests
 pytest
 ```
 
-If making changes to the documentation you can preview the changes locally using `mike`. Changes to the README can be previewed using [`grip`](https://github.com/joeyespo/grip) (not included in `dev` dependencies).
+If making changes to the documentation you can preview the changes locally using `mkdocs`. Changes to the README can be previewed using [`grip`](https://github.com/joeyespo/grip) (not included in `dev` dependencies).
 
 ```shell
-mike serve
+mkdocs serve
 ```
 
 !!! note

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,110 @@
+# Contributing
+
+Contributions are welcome!
+
+## Code of Conduct
+
+In general we follow the [Python Software Foundation Code of Conduct](https://policies.python.org/python.org/code-of-conduct/).
+
+## Pull Request Process
+
+**0. Before you begin**
+
+If you're not familiar with contributing to open source software, [start by reading this guide](https://opensource.guide/how-to-contribute/).
+
+Be aware that anything you contribute will be licenced under [the project's licence](https://github.com/nhairs/python-json-logger/blob/main/LICENSE). If you are making a change as a part of your job, be aware that your employer might own your work and you'll need their permission in order to licence the code.
+
+### 1. Find something to work on
+
+Where possible it's best to stick to established issues where discussion has already taken place. Contributions that haven't come from a discussed issue are less likely to be accepted.
+
+The following are things that can be worked on without an existing issue:
+
+- Updating documentation. This includes fixing in-code documentation / comments, and the overall docs.
+- Small changes that don't change functionality such as refactoring or adding / updating tests.
+
+### 2. Fork the repository and make your changes
+
+We don't have styling documentation, so where possible try to match existing code. This includes the use of "headings" and "dividers" (this will make sense when you look at the code).
+
+All devlopment tooling can be installed (usually into a virtual environment), using the `dev` optiontal dependency:
+
+```shell
+pip install -e '.[dev]'`
+```
+
+Before creating your pull request you'll want to format your code and run the linters and tests:
+
+```shell
+# Format
+black src tests
+
+# Lint
+pylint --output-format=colorized src
+mypy src tests
+
+# Tests
+pytest
+```
+
+If making changes to the documentation you can preview the changes locally using `mike`. Changes to the README can be previewed using [`grip`](https://github.com/joeyespo/grip) (not included in `dev` dependencies).
+
+```shell
+mike serve
+```
+
+!!! note
+    In general we will always squash merge pull requests so you do not need to worry about a "clean" commit history.
+
+### 3. Checklist
+
+Before pushing and creating your pull request, you should make sure you've done the following:
+
+- Updated any relevant tests.
+- Formatted your code and run the linters and tests.
+- Updated the version number in `pyproject.toml`. In general using a `.devN` suffix is acceptable.
+  This is not required for changes that do no affect the code such as documentation.
+- Add details of the changes to the change log (`docs/change-log.md`), creating a new section if needed.
+- Add notes for new / changed features in the relevant docstring.
+
+**4. Create your pull request**
+
+When creating your pull request be aware that the title and description will be used for the final commit so pay attention to them.
+
+Your pull request description should include the following:
+
+- Why the pull request is being made
+- Summary of changes
+- How the pull request was tested - especially if not covered by unit testing.
+
+Once you've submitted your pull request make sure that all CI jobs are passing. Pull requests will failing jobs will not be reviewed.
+
+### 5. Code review
+
+Your code will be reviewed by a maintainer.
+
+If you're not familiar with code review start by reading [this guide](https://google.github.io/eng-practices/review/).
+
+!!! tip "Remember you are not your work"
+
+    You might be asked to explain or justify your choices. This is not a criticism of your value as a person!
+
+    Often this is because there are multiple ways to solve the same problem and the reviewer would like to understand more about the way you solved.
+
+## Common Topics
+
+### Adding a new encoder
+
+New encoders may be added, however how popular / common a library is will be taken into consideration before being added.
+
+### Versioning and breaking compatability
+
+This project uses semantic versioning.
+
+In general backwards compatability is always preferred. This library is widely used and not particularly sophisticated, there must be a good reason for breaking changes.
+
+### Spelling
+
+The original implementation of this project used US spelling so it will continue to use US spelling for all code.
+
+Documentation is more flexible and may use a variety of English spellings.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ The following are things that can be worked on without an existing issue:
 
 We don't have styling documentation, so where possible try to match existing code. This includes the use of "headings" and "dividers" (this will make sense when you look at the code).
 
-All devlopment tooling can be installed (usually into a virtual environment), using the `dev` optiontal dependency:
+All devlopment tooling can be installed (usually into a virtual environment), using the `dev` optional dependency:
 
 ```shell
 pip install -e '.[dev]'`
@@ -77,7 +77,7 @@ Your pull request description should include the following:
 - Summary of changes
 - How the pull request was tested - especially if not covered by unit testing.
 
-Once you've submitted your pull request make sure that all CI jobs are passing. Pull requests will failing jobs will not be reviewed.
+Once you've submitted your pull request make sure that all CI jobs are passing. Pull requests with failing jobs will not be reviewed.
 
 ### 5. Code review
 
@@ -95,16 +95,26 @@ If you're not familiar with code review start by reading [this guide](https://go
 
 ### Adding a new encoder
 
-New encoders may be added, however how popular / common a library is will be taken into consideration before being added.
+New encoders may be added, however how popular / common a library is will be taken into consideration before being added. You should open an issue before creating a pull request.
 
 ### Versioning and breaking compatability
 
 This project uses semantic versioning.
 
-In general backwards compatability is always preferred. This library is widely used and not particularly sophisticated, there must be a good reason for breaking changes.
+In general backwards compatability is always preferred. This library is widely used and not particularly sophisticated and as such there must be a good reason for breaking changes.
+
+Feature changes MUST be compatible with all [security supported versions of Python](https://endoflife.date/python) and SHOULD be compatible with all unsupported versions of Python where [recent downloads over the last 90 days exceeds 5% of all downloads](https://pypistats.org/packages/python-json-logger).
+
+In general, only the latest `major.minor` version of Python JSON Logger is supported. Bug fixes and feature backports requiring a version branch may be considered but must be discussed with the maintainers first.
+
+See also [Security Policy](security.md).
 
 ### Spelling
 
 The original implementation of this project used US spelling so it will continue to use US spelling for all code.
 
 Documentation is more flexible and may use a variety of English spellings.
+
+### Contacting the Maintainers
+
+In general it is preferred to keep communication to GitHub, e.g. through comments on issues and pull requests. If you do need to contact the maintainers privately, please do so using the email addresses in the maintainers section of the `pyproject.toml`.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,157 @@
+# Cookbook
+
+Recipies for common tasks.
+
+## Include all fields
+
+This can be achieved by setting `reserved_attrs=[]` when creating the formatter.
+
+## Custom Styles
+
+It is possible to support custom `style`s by setting `validate=False` and overriding the `parse` method.
+
+For example:
+
+```python
+class CommaSupport(JsonFormatter):
+    def parse(self) -> list[str]:
+        if isinstance(self._style, str) and self._style == ",":
+            return self._fmt.split(",")
+        return super().parse()
+
+formatter = CommaSupport("message,asctime", style=",", validate=False)
+```
+
+## Modifying the logged data
+
+You can modify the `dict` of data that will be logged by overriding the `process_log_record` method to modify fields before they are serialized to JSON.
+
+```python
+class SillyFormatter(JsonFormatter):
+    def process_log_record(log_record):
+        new_record = {k[::-1]: v for k, v in log_record.items()}
+        return new_record
+```
+
+
+## Request / Trace IDs
+
+There are many ways to add consistent request IDs to your logging. The exact method will depend on your needs and application.
+
+```python
+import logging
+import uuid
+from pythonjsonlogger.json import JsonFormatter
+
+## Setup
+## -----------------------------------------------------------------------------
+logger = logging.getLogger("test")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+logger.addHandler(handler)
+
+## Solution 1
+## -----------------------------------------------------------------------------
+formatter = JsonFormatter()
+handler.setFormatter(formatter)
+
+def main_1():
+    print("========== MAIN 1 ==========")
+    for i in range(3):
+        request_id = uuid.uuid4().hex
+        logger.info("loop start", extra={"request_id": request_id})
+        logger.info(f"loop {i}", extra={"request_id": request_id})
+        logger.info("loop end", extra={"request_id": request_id})
+    return
+
+main_1()
+
+## Solution 2
+## -----------------------------------------------------------------------------
+REQUEST_ID: str | None = None
+
+def get_request_id() -> str:
+    return REQUEST_ID
+
+def generate_request_id():
+    global REQUEST_ID
+    REQUEST_ID = uuid.uuid4().hex
+
+class RequestIdFilter(logging.Filter):
+    # Ref: https://docs.python.org/3/howto/logging-cookbook.html#using-filters-to-impart-contextual-information
+
+    def filter(self, record):
+        record.record_id = get_request_id()
+        return True
+
+request_id_filter = RequestIdFilter()
+logger.addFilter(request_id_filter)
+
+def main_2():
+    print("========== MAIN 2 ==========")
+    for i in range(3):
+        generate_request_id()
+        logger.info("loop start")
+        logger.info(f"loop {i}")
+        logger.info("loop end")
+    return
+
+main_2()
+
+logger.removeFilter(request_id_filter)
+
+## Solution 3
+## -----------------------------------------------------------------------------
+# Reuse REQUEST_ID stuff from solution 2
+class MyFormatter(JsonFormatter):
+    def process_log_record(self, log_record):
+        log_record["request_id"] = get_request_id()
+        return log_record
+
+handler.setFormatter(MyFormatter())
+
+def main_3():
+    print("========== MAIN 3 ==========")
+    for i in range(3):
+        generate_request_id()
+        logger.info("loop start")
+        logger.info(f"loop {i}")
+        logger.info("loop end")
+    return
+
+main_3()
+```
+
+### Using `fileConfig`
+
+To use the module with a config file using the [`fileConfig` function](https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig), use the class `pythonjsonlogger.json.JsonFormatter`. Here is a sample config file.
+
+```ini
+[loggers]
+keys = root,custom
+
+[logger_root]
+handlers =
+
+[logger_custom]
+level = INFO
+handlers = custom
+qualname = custom
+
+[handlers]
+keys = custom
+
+[handler_custom]
+class = StreamHandler
+level = INFO
+formatter = json
+args = (sys.stdout,)
+
+[formatters]
+keys = json
+
+[formatter_json]
+format = %(message)s
+class = pythonjsonlogger.jsonlogger.JsonFormatter
+```
+

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -122,7 +122,7 @@ def main_3():
 main_3()
 ```
 
-### Using `fileConfig`
+## Using `fileConfig`
 
 To use the module with a config file using the [`fileConfig` function](https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig), use the class `pythonjsonlogger.json.JsonFormatter`. Here is a sample config file.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,62 @@
+# Python JSON Logger
+
+<!-- [![PyPi](https://img.shields.io/pypi/v/python-json-logger.svg)](https://pypi.python.org/pypi/python-json-logger/)
+[![PyPI - Status](https://img.shields.io/pypi/status/python-json-logger)](https://pypi.python.org/pypi/python-json-logger/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/python-json-logger.svg)](https://github.com/nhairs/python-json-logger) -->
+[![License](https://img.shields.io/github/license/nhairs/python-json-logger.svg)](https://github.com/nhairs/python-json-logger)
+![Build Status](https://github.com/nhairs/python-json-logger/actions/workflows/test-suite.yml/badge.svg)
+
+## Introduction
+
+This library is provided to allow standard python logging to output log data as json objects. With JSON we can make our logs more readable by machines and we can stop writing custom parsers for syslog type records.
+
+!!! warning
+    This repository is a maintained fork of [madzak/python-json-logger](https://github.com/madzak/python-json-logger) pending [a PEP 541 request](https://github.com/pypi/support/issues/3607) for the PyPI package.  The future direction of the project is being discussed [here](https://github.com/nhairs/python-json-logger/issues/1).
+
+
+## Features
+
+- **TODO?:** TODO.
+- **Multiple Encoders:** In addition to the standard libary's `json` module, also supports 3rd party encoders: `orjson`, `msgspec`
+
+## Quick Start
+
+Follow our [Quickstart Guide](quickstart.md).
+
+```python title="TLDR"
+import logging
+from pythonjsonlogger.json import JsonFormatter
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+handler = logging.StreamHandler()
+handler.setFormatter(JsonFormatter())
+
+logger.addHandler(handler)
+
+logger.info("Logging using pythonjsonlogger!", extra={"more_data": True})
+
+# {"message": "Logging using pythonjsonlogger!", "more_data": true}
+```
+
+
+## Bugs, Feature Requests etc
+Please [submit an issue on github](https://github.com/nhairs/python-json-logger/issues).
+
+In the case of bug reports, please help us help you by following best practices [^1^](https://marker.io/blog/write-bug-report/) [^2^](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
+
+In the case of feature requests, please provide background to the problem you are trying to solve so to help find a solution that makes the most sense for the library as well as your usecase.
+
+
+## License
+
+This project is licensed under the BSD 2 Clause License - see [`LICENSE`](https://github.com/nhairs/python-json-logger/blob/main/LICENSE)
+
+## Authors and Maintainers
+
+This project was originally authored by [Zakaria Zajac](https://github.com/madzak) and our wonderful [contributors](https://github.com/nhairs/python-json-logger/graphs/contributors)
+
+It is currently maintained by:
+
+- [Nicholas Hairs](https://github.com/nhairs) - [nicholashairs.com](https://www.nicholashairs.com)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,12 @@
 
 ## Introduction
 
-This library is provided to allow standard python logging to output log data as json objects. With JSON we can make our logs more readable by machines and we can stop writing custom parsers for syslog type records.
+Python JSON Logger enables you produce JSON logs when using Python's `logging` package.
+
+JSON logs are machine readable allowing for much easier parsing and ingestion into log aggregation tools.
+
+This library assumes that you are famliar with the `logging` standard library package; if you are not you should start by reading the official [Logging HOWTO](https://docs.python.org/3/howto/logging.html).
+
 
 !!! warning
     This repository is a maintained fork of [madzak/python-json-logger](https://github.com/madzak/python-json-logger) pending [a PEP 541 request](https://github.com/pypi/support/issues/3607) for the PyPI package.  The future direction of the project is being discussed [here](https://github.com/nhairs/python-json-logger/issues/1).
@@ -16,8 +21,10 @@ This library is provided to allow standard python logging to output log data as 
 
 ## Features
 
-- **TODO?:** TODO.
-- **Multiple Encoders:** In addition to the standard libary's `json` module, also supports 3rd party encoders: `orjson`, `msgspec`
+- **Standard Library Compatible:** Implement JSON logging without modifying your existing log setup.
+- **Supports Multiple JSON Encoders:** In addition to the standard libary's `json` module, also supports the [`orjson`][pythonjsonlogger.orjson], [`msgspec`][pythonjsonlogger.msgspec] JSON encoders.
+- **Fully Customizable Output Fields:** Control required, excluded, and static fields including automatically picking up custom attributes on `LogRecord` objects. Fields can be renamed before they are output.
+- **Encode Any Type:** Encoders are customized to ensure that something sane is logged for any input including those that aren't supported by default. For example formatting UUID objects into their string representation and bytes objects into a base 64 encoded string.
 
 ## Quick Start
 
@@ -46,8 +53,7 @@ Please [submit an issue on github](https://github.com/nhairs/python-json-logger/
 
 In the case of bug reports, please help us help you by following best practices [^1^](https://marker.io/blog/write-bug-report/) [^2^](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
 
-In the case of feature requests, please provide background to the problem you are trying to solve so to help find a solution that makes the most sense for the library as well as your usecase.
-
+In the case of feature requests, please provide background to the problem you are trying to solve so that we can a solution that makes the most sense for the library as well as your use case.
 
 ## License
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,10 @@
 
 ## Installation
 
-Note: All versions of this fork use version `>=3.0.0` - to use pre-fork versions use `python-json-logger<3.0.0`.
+!!! note
+    All versions of this fork use version `>=3.0.0`.
+
+    To use pre-fork versions use `python-json-logger<3`.
 
 ### Install via pip
 
@@ -10,7 +13,7 @@ Until the PEP 541 request is complete you will need to install directly from git
 
 #### Install from GitHub
 
-To install from releases:
+To install from [releases](https://github.com/nhairs/python-json-logger/releases) (including development releases), you can use the URL to the specific wheel.
 
 ```shell
 # e.g. 3.0.0 wheel
@@ -19,7 +22,7 @@ pip install 'python-json-logger@https://github.com/nhairs/python-json-logger/rel
 
 ## Usage
 
-Python JSON Logger provides `logging.Formatter`s that encode the logged message into JSON. Although a variety of JSON encoders are supported, in the following examples we will use the [pythonjsonlogger.json.JsonFormatter][] which uses the the `json` module from the standard library.
+Python JSON Logger provides [`logging.Formatter`](https://docs.python.org/3/library/logging.html#logging.Formatter) classes that encode the logged message into JSON. Although [a variety of JSON encoders are supported](#alternate-json-encoders), the following examples will use the [JsonFormatter][pythonjsonlogger.json.JsonFormatter] which uses the the `json` module from the standard library.
 
 ### Integrating with Python's logging framework
 
@@ -87,7 +90,7 @@ formatter = JsonFormatter(
 
 ### Excluding fields
 
-You can prevent fields being added to the output data by adding them to `reserved_attrs`.
+You can prevent fields being added to the output data by adding them to `reserved_attrs`. By default all [`LogRecord` attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) are exluded.
 
 ```python
 from pythonjsonlogger.core import RESERVED_ATTRS
@@ -112,8 +115,6 @@ formatter = JsonFormatter(
 ### Custom object serialization
 
 Most formatters support `json_default` which is used to control how objects are serialized.
-
-For custom handling of object serialization you can specify default json object translator or provide a custom encoder
 
 ```python
 def my_default(obj):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,102 @@
+# Quick Start
+
+## Installation
+
+Note: All versions of this fork use version `>=3.0.0` - to use pre-fork versions use `python-json-logger<3.0.0`.
+
+### Install via pip
+
+Until the PEP 541 request is complete you will need to install directly from github.
+
+#### Install from GitHub
+
+To install from releases:
+
+```shell
+# e.g. 3.0.0 wheel
+pip install 'python-json-logger@https://github.com/nhairs/python-json-logger/releases/download/v3.0.0/python_json_logger-3.0.0-py3-none-any.whl'
+```
+
+## Usage
+
+Python JSON Logger provides `logging.Formatter`s that encode the logged message into JSON. Although a variety of JSON encoders are supported, in the following examples we will use the [pythonjsonlogger.json.JsonFormatter][] which uses the the `json` module from the standard library.
+
+### Integrating with Python's logging framework
+
+To produce JSON output, attach the formatter to a logging handler:
+
+```python
+import logging
+from pythonjsonlogger.json import JsonFormatter
+
+logger = logging.getLogger()
+
+logHandler = logging.StreamHandler()
+formatter = JsonFormatter()
+logHandler.setFormatter(formatter)
+logger.addHandler(logHandler)
+```
+
+### Output fields
+
+#### Format Fields
+You can control the logged fields by setting the `fmt` argument when creating the formatter. By default formatters will follow the same `style` of `fmt` as the `logging` module: `%`, `$`, and `{`. All [`LogRecord` attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) can be output using their name.
+
+```python
+formatter = JsonFormatter("{message}{asctime}{exc_info}", style="{")
+```
+
+#### Extra Fields
+You can also add extra fields to your json output by specifying a dict in place of message, as well as by specifying an `extra={}` argument. Contents of these dictionaries will be added at the root level of the entry and may override basic fields.
+
+Non-standard attributes added to a `LogRecord` will also be included in the logged data.
+
+#### Static Fields
+
+Static data that is added to every log record can be set using the `static_fields` argument.
+
+```python
+formatter = JsonFormatter(static_fields={"True gets logged on every record?": True})
+```
+
+### Excluding fields
+
+You can prevent fields being added to the output data by adding them to `reserved_attrs`.
+
+```python
+from pythonjsonlogger.core import RESERVED_ATTRS
+
+formatter = JsonFormatter(reserved_attrs=RESERVED_ATTRS+["request_id", "my_other_field"])
+```
+
+### Renaming fields
+
+You can rename fields using the `rename_fields` argument.
+
+```python
+formatter = JsonFormatter("{message}{levelname}", style="{", rename_fields={"levelname": "LEVEL"})
+```
+
+### Custom object serialization
+
+Most formatters support `json_default` which is used to control how objects are serialized.
+
+For custom handling of object serialization you can specify default json object translator or provide a custom encoder
+
+```python
+def my_default(obj):
+    if isinstance(obj, MyClass):
+        return {"special": obj.special}
+
+formatter = JsonFormatter(json_default=my_default)
+```
+
+!!! note
+    When providing your own `json_default`, you likely want to call the original `json_default` for your encoder. Python JSON Logger provides custom default serializers for each encoder that tries very hard to ensure sane output is always logged.
+
+### Alternate JSON Encoders
+
+The following JSON encoders are also supported:
+
+- [orjson](https://github.com/ijl/orjson) - [pythonjsonlogger.orjson.OrjsonFormatter][]
+- [msgspec](https://github.com/jcrist/msgspec) - [pythonjsonlogger.msgspec.MsgspecFormatter][]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,24 +39,50 @@ logger.addHandler(logHandler)
 
 ### Output fields
 
-#### Format Fields
+#### Required Fields
 You can control the logged fields by setting the `fmt` argument when creating the formatter. By default formatters will follow the same `style` of `fmt` as the `logging` module: `%`, `$`, and `{`. All [`LogRecord` attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) can be output using their name.
 
 ```python
 formatter = JsonFormatter("{message}{asctime}{exc_info}", style="{")
 ```
 
-#### Extra Fields
-You can also add extra fields to your json output by specifying a dict in place of message, as well as by specifying an `extra={}` argument. Contents of these dictionaries will be added at the root level of the entry and may override basic fields.
+#### Message Fields
 
-Non-standard attributes added to a `LogRecord` will also be included in the logged data.
+Instead of logging a string message you can log using a `dict`.
+
+```python
+logger.info({
+    "my_data": 1,
+    "message": "if you don't include this it will be an empty string",
+    "other_stuff": False,
+})
+```
+
+!!! warning
+    Be aware that if you log using a `dict`, other formatters may not be able to handle it.
+
+You can also add additional message fields using the `extra` argument.
+
+```python
+logger.info(
+    "this logs the same additional fields as above",
+    extra={
+        "my_data": 1,
+        "other_stuff": False,
+    },
+)
+```
+
+Finally, any non-standard attributes added to a `LogRecord` will also be included in the logged data. See [Cookbook: Request / Trace IDs](cookbook.md#request-trace-ids) for an example.
 
 #### Static Fields
 
-Static data that is added to every log record can be set using the `static_fields` argument.
+Static fields that are added to every log record can be set using the `static_fields` argument.
 
 ```python
-formatter = JsonFormatter(static_fields={"True gets logged on every record?": True})
+formatter = JsonFormatter(
+    static_fields={"True gets logged on every record?": True}
+)
 ```
 
 ### Excluding fields
@@ -66,7 +92,9 @@ You can prevent fields being added to the output data by adding them to `reserve
 ```python
 from pythonjsonlogger.core import RESERVED_ATTRS
 
-formatter = JsonFormatter(reserved_attrs=RESERVED_ATTRS+["request_id", "my_other_field"])
+formatter = JsonFormatter(
+    reserved_attrs=RESERVED_ATTRS+["request_id", "my_other_field"]
+)
 ```
 
 ### Renaming fields
@@ -74,7 +102,11 @@ formatter = JsonFormatter(reserved_attrs=RESERVED_ATTRS+["request_id", "my_other
 You can rename fields using the `rename_fields` argument.
 
 ```python
-formatter = JsonFormatter("{message}{levelname}", style="{", rename_fields={"levelname": "LEVEL"})
+formatter = JsonFormatter(
+    "{message}{levelname}",
+    style="{",
+    rename_fields={"levelname": "LEVEL"},
+)
 ```
 
 ### Custom object serialization

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security support for Python JSON Logger is provided for all [security supported versions of Python](https://endoflife.date/python) and for unsupported versions of Python where [recent downloads over the last 90 days exceeds 5% of all downloads](https://pypistats.org/packages/python-json-logger).
+
+
+As of 2024-04-24 security support is provided for Python versions `3.8+`.
+
+
+## Reporting a Vulnerability
+
+Please report vulnerabilties [using GitHub](https://github.com/nhairs/python-json-logger/security/advisories/new).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,113 @@
+site_name: "Python JSON Logger"
+site_url: https://nhairs.github.io/python-json-logger
+repo_url: https://github.com/nhairs/python-json-logger
+edit_uri: tree/master/docs
+copyright: "<a href='https://github.com/nhairs/python-json-logger/graphs/contributors'> Copyright &copy; Python JSON Logger Contributors</a>"
+watch:
+  - mkdocs.yml
+  - README.md
+  - src/pythonjsonlogger
+  - docs
+
+nav:
+  - "Home": index.md
+  - quickstart.md
+  - cookbook.md
+  - changelog.md
+  - security.md
+  - contributing.md
+  - API Reference:
+    - ... | reference/pythonjsonlogger/*
+
+theme:
+  name: material
+
+  icon:
+    logo: material/code-braces
+
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.indexes
+    - navigation.expand
+    - navigation.top
+    - content.code.annotate
+    - content.code.copy
+    - toc.follow
+
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      primary: amber
+      scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      primary: amber
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/nhairs/python-json-logger
+  version:
+    provider: mike
+
+markdown_extensions:
+  - toc:
+      permalink: "🔗"
+  - admonition
+  - def_list
+  - mdx_truly_sane_lists
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.caret
+
+plugins:
+  - autorefs
+  - search:
+      lang: en
+  - awesome-pages:
+      collapse_single_pages: true
+  - gen-files:
+      scripts:
+        - scripts/gen_ref_nav.py
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths:
+            - src
+          #import:
+          #  - https://docs.python.org/3/objects.inv
+          #  - https://mkdocstrings.github.io/objects.inv
+          #  - https://mkdocstrings.github.io/griffe/objects.inv
+          options:
+            filters:
+              - "!^_"
+            heading_level: 1
+            inherited_members: true
+            merge_init_into_class: true
+            #preload_modules: []
+            separate_signature: true
+            show_root_heading: true
+            show_root_full_path: true
+            show_signature_annotations: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            signature_crossrefs: true
+            summary: true
+            unwrap_annotated: true
+            show_source: false
+  - literate-nav:
+      nav_file: SUMMARY.txt
+  - mike:
+      canonical_version: latest
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,8 +85,8 @@ plugins:
         python:
           paths:
             - src
-          #import:
-          #  - https://docs.python.org/3/objects.inv
+          import:
+            - https://docs.python.org/3/objects.inv
           #  - https://mkdocstrings.github.io/objects.inv
           #  - https://mkdocstrings.github.io/griffe/objects.inv
           options:
@@ -106,6 +106,7 @@ plugins:
             summary: true
             unwrap_annotated: true
             show_source: false
+            docstring_section_style: spacy
   - literate-nav:
       nav_file: SUMMARY.txt
   - mike:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 ]
 
 [project.urls]
-# homepage = "https://nhairs.github.io/python-json-logger/latest/"
+Homepage = "https://nhairs.github.io/python-json-logger/latest/"
 GitHub = "https://github.com/nhairs/python-json-logger"
 
 [project.optional-dependencies]
@@ -59,6 +59,15 @@ dev = [
     "tzdata",
     ## Build
     "build",
+    ## Docs
+    "mkdocs",
+    "mkdocs-material>=8.5",
+    "mkdocs-awesome-pages-plugin",
+    "mdx_truly_sane_lists",
+    "mkdocstrings[python]",
+    "mkdocs-gen-files",
+    "mkdocs-literate-nav",
+    "mike",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/gen_ref_nav.py
+++ b/scripts/gen_ref_nav.py
@@ -1,0 +1,35 @@
+# NOTICE: This file is from mkdocstrings-python see NOTICE for details
+"""Generate the code reference pages and navigation."""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+mod_symbol = '<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code>'
+
+for path in sorted(Path("src").rglob("*.py")):
+    module_path = path.relative_to("src").with_suffix("")
+    doc_path = path.relative_to("src").with_suffix(".md")
+    full_doc_path = Path("reference", doc_path)
+
+    parts = tuple(module_path.parts)
+
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+    elif parts[-1].startswith("_"):
+        continue
+
+    nav_parts = [f"{mod_symbol} {part}" for part in parts]
+    nav[tuple(nav_parts)] = doc_path.as_posix()
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        ident = ".".join(parts)
+        fd.write(f"::: {ident}")
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, ".." / path)
+
+with mkdocs_gen_files.open("reference/SUMMARY.txt", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -25,9 +25,6 @@ else:
 
 ### CONSTANTS
 ### ============================================================================
-# skip natural LogRecord attributes
-# http://docs.python.org/library/logging.html#logrecord-attributes
-# Changed in 3.0.0, is now list[str] instead of tuple[str, ...]
 RESERVED_ATTRS: List[str] = [
     "args",
     "asctime",
@@ -52,6 +49,16 @@ RESERVED_ATTRS: List[str] = [
     "thread",
     "threadName",
 ]
+"""Default reserved attributes.
+
+These come from the [default attributes of `LogRecord` objects](http://docs.python.org/library/logging.html#logrecord-attributes).
+
+Note:
+    Although considered a constant, this list is dependent on the Python version due to
+    different `LogRecord` objects having different attributes in different Python versions.
+
+*Changed in 3.0*: `RESERVED_ATTRS` is now `list[str]` instead of `tuple[str, ...]`.
+"""
 
 if sys.version_info >= (3, 12):
     # taskName added in python 3.12
@@ -66,7 +73,10 @@ STYLE_PERCENT_REGEX = re.compile(r"%\((.+?)\)", re.IGNORECASE)
 ## Type Aliases
 ## -----------------------------------------------------------------------------
 OptionalCallableOrStr: TypeAlias = Optional[Union[Callable, str]]
+"""Type alias"""
+
 LogRecord: TypeAlias = Dict[str, Any]
+"""Type alias"""
 
 
 ### FUNCTIONS
@@ -117,9 +127,9 @@ def merge_record_extra(
 ### CLASSES
 ### ============================================================================
 class BaseJsonFormatter(logging.Formatter):
-    """Base class for pythonjsonlogger formatters
+    """Base class for all formatters
 
-    Must not be used directly
+    Must not be used directly.
 
     *New in 3.1*
     """
@@ -159,8 +169,7 @@ class BaseJsonFormatter(logging.Formatter):
             rename_fields_keep_missing: When renaming fields, include missing fields in the output.
             static_fields: an optional dict, used to add fields with static values to all logs
             reserved_attrs: an optional list of fields that will be skipped when
-                outputting json log record. Defaults to all log record attributes:
-                http://docs.python.org/library/logging.html#logrecord-attributes
+                outputting json log record. Defaults to [all log record attributes][pythonjsonlogger.core.RESERVED_ATTRS].
             timestamp: an optional string/boolean field to add a timestamp when
                 outputting the json log record. If string is passed, timestamp will be added
                 to log record using string as key. If True boolean is passed, timestamp key

--- a/src/pythonjsonlogger/defaults.py
+++ b/src/pythonjsonlogger/defaults.py
@@ -1,4 +1,10 @@
-# pylint: disable=missing-function-docstring
+"""Collection of functions for building custom `json_default` functions.
+
+In general functions come in pairs of `use_x_default` and `x_default`, where the former is used
+to determine if you should call the latter.
+
+Most `use_x_default` functions also act as a [`TypeGuard`](https://mypy.readthedocs.io/en/stable/type_narrowing.html#user-defined-type-guards).
+"""
 
 ### IMPORTS
 ### ============================================================================
@@ -29,6 +35,14 @@ else:
 ### FUNCTIONS
 ### ============================================================================
 def unknown_default(obj: Any) -> str:
+    """Backup default function for any object type.
+
+    Will attempt to use `str` or `repr`. If both functions error will return
+    the string `"__could_not_encode__"`.
+
+    Args:
+        obj: object to handle
+    """
     try:
         return str(obj)
     except Exception:  # pylint: disable=broad-exception-caught
@@ -43,82 +57,145 @@ def unknown_default(obj: Any) -> str:
 ## Types
 ## -----------------------------------------------------------------------------
 def use_type_default(obj: Any) -> TypeGuard[type]:
+    """Default check function for `type` objects (aka classes)."""
     return isinstance(obj, type)
 
 
 def type_default(obj: type) -> str:
+    """Default function for `type` objects.
+
+    Args:
+        obj: object to handle
+    """
     return obj.__name__
 
 
 ## Dataclasses
 ## -----------------------------------------------------------------------------
 def use_dataclass_default(obj: Any) -> bool:
+    """Default check function for dataclass instances"""
     return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
 
 
 def dataclass_default(obj) -> dict[str, Any]:
+    """Default function for dataclass instances
+
+    Args:
+        obj: object to handle
+    """
     return dataclasses.asdict(obj)
 
 
 ## Dates and Times
 ## -----------------------------------------------------------------------------
 def use_time_default(obj: Any) -> TypeGuard[datetime.time]:
+    """Default check function for `datetime.time` instances"""
     return isinstance(obj, datetime.time)
 
 
 def time_default(obj: datetime.time) -> str:
+    """Default function for `datetime.time` instances
+
+    Args:
+        obj: object to handle
+    """
     return obj.isoformat()
 
 
 def use_date_default(obj: Any) -> TypeGuard[datetime.date]:
+    """Default check function for `datetime.date` instances"""
     return isinstance(obj, datetime.date)
 
 
 def date_default(obj: datetime.date) -> str:
+    """Default function for `datetime.date` instances
+
+    Args:
+        obj: object to handle
+    """
     return obj.isoformat()
 
 
 def use_datetime_default(obj: Any) -> TypeGuard[datetime.datetime]:
+    """Default check function for `datetime.datetime` instances"""
     return isinstance(obj, datetime.datetime)
 
 
 def datetime_default(obj: datetime.datetime) -> str:
+    """Default function for `datetime.datetime` instances
+
+    Args:
+        obj: object to handle
+    """
     return obj.isoformat()
 
 
 def use_datetime_any(obj: Any) -> TypeGuard[datetime.time | datetime.date | datetime.datetime]:
+    """Default check function for `datetime` related instances"""
     return isinstance(obj, (datetime.time, datetime.date, datetime.datetime))
 
 
 def datetime_any(obj: datetime.time | datetime.date | datetime.date) -> str:
+    """Default function for `datetime` related instances
+
+    Args:
+        obj: object to handle
+    """
     return obj.isoformat()
 
 
 ## Exception and Tracebacks
 ## -----------------------------------------------------------------------------
 def use_exception_default(obj: Any) -> TypeGuard[BaseException]:
+    """Default check function for exception instances.
+
+    Exception classes are not treated specially and should be handled by the
+    `[use_]type_default` functions.
+    """
     return isinstance(obj, BaseException)
 
 
 def exception_default(obj: BaseException) -> str:
+    """Default function for exception instances
+
+    Args:
+        obj: object to handle
+    """
     return f"{obj.__class__.__name__}: {obj}"
 
 
 def use_traceback_default(obj: Any) -> TypeGuard[TracebackType]:
+    """Default check function for tracebacks"""
     return isinstance(obj, TracebackType)
 
 
 def traceback_default(obj: TracebackType) -> str:
+    """Default function for tracebacks
+
+    Args:
+        obj: object to handle
+    """
     return "".join(traceback.format_tb(obj)).strip()
 
 
 ## Enums
 ## -----------------------------------------------------------------------------
 def use_enum_default(obj: Any) -> TypeGuard[enum.Enum | enum.EnumMeta]:
+    """Default check function for enums.
+
+    Supports both enum classes and enum values.
+    """
     return isinstance(obj, (enum.Enum, enum.EnumMeta))
 
 
 def enum_default(obj: enum.Enum | enum.EnumMeta) -> Any | list[Any]:
+    """Default function for enums.
+
+    Supports both enum classes and enum values.
+
+    Args:
+        obj: object to handle
+    """
     if isinstance(obj, enum.Enum):
         return obj.value
     return [e.value for e in obj]  # type: ignore[var-annotated]
@@ -127,20 +204,38 @@ def enum_default(obj: enum.Enum | enum.EnumMeta) -> Any | list[Any]:
 ## UUIDs
 ## -----------------------------------------------------------------------------
 def use_uuid_default(obj: Any) -> TypeGuard[uuid.UUID]:
+    """Default check function for `uuid.UUID` instances"""
     return isinstance(obj, uuid.UUID)
 
 
 def uuid_default(obj: uuid.UUID) -> str:
+    """Default function for `uuid.UUID` instances
+
+    Formats the UUID using "hyphen" format.
+
+    Args:
+        obj: object to handle
+    """
     return str(obj)
 
 
 ## Bytes
 ## -----------------------------------------------------------------------------
 def use_bytes_default(obj: Any) -> TypeGuard[bytes | bytearray]:
+    """Default check function for bytes"""
     return isinstance(obj, (bytes, bytearray))
 
 
 def bytes_default(obj: bytes | bytearray, url_safe: bool = True) -> str:
+    """Default function for bytes
+
+    Args:
+        obj: object to handle
+        url_safe: use URL safe base 64 character set.
+
+    Returns:
+        The byte data as a base 64 string.
+    """
     if url_safe:
         return base64.urlsafe_b64encode(obj).decode("utf8")
     return base64.b64encode(obj).decode("utf8")

--- a/src/pythonjsonlogger/json.py
+++ b/src/pythonjsonlogger/json.py
@@ -23,11 +23,7 @@ from . import defaults as d
 ### CLASSES
 ### ============================================================================
 class JsonEncoder(json.JSONEncoder):
-    """A custom encoder extending the default JSONEncoder
-
-    Refs:
-    - https://docs.python.org/3/library/json.html
-    """
+    """A custom encoder extending [json.JSONEncoder](https://docs.python.org/3/library/json.html#json.JSONEncoder)"""
 
     def default(self, o: Any) -> Any:
         if d.use_datetime_any(o):
@@ -57,7 +53,7 @@ class JsonEncoder(json.JSONEncoder):
             return d.unknown_default(o)
 
     def format_datetime_obj(self, o: datetime.time | datetime.date | datetime.datetime) -> str:
-        """Format datetime objects found in self.default
+        """Format datetime objects found in `self.default`
 
         This allows subclasses to change the datetime format without understanding the
         internals of the default method.
@@ -66,7 +62,7 @@ class JsonEncoder(json.JSONEncoder):
 
 
 class JsonFormatter(core.BaseJsonFormatter):
-    """JSON formatter using the standard library's `json` for encoding"""
+    """JSON formatter using the standard library's [`json`](https://docs.python.org/3/library/json.html) for encoding"""
 
     def __init__(
         self,
@@ -80,13 +76,14 @@ class JsonFormatter(core.BaseJsonFormatter):
     ) -> None:
         """
         Args:
+            args: see [BaseJsonFormatter][pythonjsonlogger.core.BaseJsonFormatter]
             json_default: a function for encoding non-standard objects
-                as outlined in https://docs.python.org/3/library/json.html
-            json_encoder: optional custom encoder
-            json_serializer: a :meth:`json.dumps`-compatible callable
+            json_encoder: custom JSON encoder
+            json_serializer: a [`json.dumps`](https://docs.python.org/3/library/json.html#json.dumps)-compatible callable
                 that will be used to serialize the log record.
-            json_indent: indent parameter for json.dumps
-            json_ensure_ascii: ensure_ascii parameter for json.dumps
+            json_indent: indent parameter for the `json_serializer`
+            json_ensure_ascii: `ensure_ascii` parameter for the `json_serializer`
+            kwargs: see [BaseJsonFormatter][pythonjsonlogger.core.BaseJsonFormatter]
         """
         super().__init__(*args, **kwargs)
 
@@ -100,6 +97,7 @@ class JsonFormatter(core.BaseJsonFormatter):
         return
 
     def jsonify_log_record(self, log_record: core.LogRecord) -> str:
+        """Returns a json string of the log record."""
         return self.json_serializer(
             log_record,
             default=self.json_default,

--- a/src/pythonjsonlogger/msgspec.py
+++ b/src/pythonjsonlogger/msgspec.py
@@ -1,3 +1,5 @@
+"""JSON Formatter using [`msgspec`](https://github.com/jcrist/msgspec)"""
+
 ### IMPORTS
 ### ============================================================================
 ## Future
@@ -32,13 +34,8 @@ def msgspec_default(obj: Any) -> Any:
 ### CLASSES
 ### ============================================================================
 class MsgspecFormatter(core.BaseJsonFormatter):
-    """JSON formatter using msgspec.json for encoding.
+    """JSON formatter using [`msgspec.json.Encoder`](https://jcristharif.com/msgspec/api.html#msgspec.json.Encoder) for encoding."""
 
-    Refs:
-    - https://jcristharif.com/msgspec/api.html#msgspec.json.Encoder
-    """
-
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         *args,
@@ -47,7 +44,9 @@ class MsgspecFormatter(core.BaseJsonFormatter):
     ) -> None:
         """
         Args:
-            json_default: a function for encoding non-standard objects see: `msgspec.json.Encode:enc_hook`
+            args: see [BaseJsonFormatter][pythonjsonlogger.core.BaseJsonFormatter]
+            json_default: a function for encoding non-standard objects
+            kwargs: see [BaseJsonFormatter][pythonjsonlogger.core.BaseJsonFormatter]
         """
         super().__init__(*args, **kwargs)
 

--- a/src/pythonjsonlogger/orjson.py
+++ b/src/pythonjsonlogger/orjson.py
@@ -1,3 +1,5 @@
+"""JSON Formatter using [msgspec](https://github.com/ijl/orjson)"""
+
 ### IMPORTS
 ### ============================================================================
 ## Future
@@ -34,13 +36,8 @@ def orjson_default(obj: Any) -> Any:
 ### CLASSES
 ### ============================================================================
 class OrjsonFormatter(core.BaseJsonFormatter):
-    """JSON formatter using orjson for encoding.
+    """JSON formatter using [orjson](https://github.com/ijl/orjson) for encoding."""
 
-    Refs:
-    - https://github.com/ijl/orjson
-    """
-
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         *args,
@@ -50,10 +47,10 @@ class OrjsonFormatter(core.BaseJsonFormatter):
     ) -> None:
         """
         Args:
-            json_default: a function for encoding non-standard objects see:
-                https://github.com/ijl/orjson#default
-            json_indent: indent output with 2 spaces. see:
-                https://github.com/ijl/orjson#opt_indent_2
+            args: see [BaseJsonFormatter][pythonjsonlogger.core.BaseJsonFormatter]
+            json_default: a function for encoding non-standard objects
+            json_indent: indent output with 2 spaces.
+            kwargs: see [BaseJsonFormatter][pythonjsonlogger.core.BaseJsonFormatter]
         """
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
This pull request moves the existing documentation to `mkdocs` for generation.

This includes setting links for use with GitHub Pages.

## Test Plan

View the docs locally using `mkdocs serve`.