### PR TITLE
[pyproject] Support Python 3.13

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -44,7 +44,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13-dev"
+          - "3.13"
         os:
           - ubuntu-latest
           - windows-latest

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pythonjsonlogger.[orjson,msgspec]` now throws a `pythonjsonlogger.exception.MissingPackageError` when required libraries are not available. These contain more information about what is missing whilst still being an `ImportError`.
 - `defaults` parameter is no longer ignored and now conforms to the standard library. Setting a defaults dictionary will add the specified keys if the those keys do not exist in a record or weren't passed by the `extra` parameter when logging a message.
 - `typing_extensions` is only installed on Python version < 3.10.
+- Support Python 3.13
+  - `msgspec` has only been tested against pre-release versions.
 
 Thanks @cjwatson and @bharel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     ## Optional but required for dev
     "orjson;implementation_name!='pypy'",
     "msgspec;implementation_name!='pypy' and python_version<'3.13'",
+    "msgspec-python313-pre;implementation_name!='pypy' and python_version=='3.13'",
     ## Lint
     "validate-pyproject[all]",
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Logging",
     "Typing :: Typed",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ GitHub = "https://github.com/nhairs/python-json-logger"
 dev = [
     ## Optional but required for dev
     "orjson;implementation_name!='pypy'",
-    "msgspec;implementation_name!='pypy'",
+    "msgspec;implementation_name!='pypy' and python_version<'3.13'",
     ## Lint
     "validate-pyproject[all]",
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ GitHub = "https://github.com/nhairs/python-json-logger"
 [project.optional-dependencies]
 dev = [
     ## Optional but required for dev
-    "orjson;implementation_name!='pypy' and python_version<'3.13'",
-    "msgspec;implementation_name!='pypy' and python_version<'3.13'",
+    "orjson;implementation_name!='pypy'",
+    "msgspec;implementation_name!='pypy'",
     ## Lint
     "validate-pyproject[all]",
     "black",


### PR DESCRIPTION
Resume testing orjson and msgspec against python 3.13.

At the time of release for v3.1.0, orjon and msgspec could not be installed on python 3.13 as the packages did not support it.

### Test Plan
- Unit tests