### PR TITLE
Restrict typing_extensions requirement to < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers  = [
 # Dependency Information
 requires-python = ">=3.8"
 dependencies = [
-    "typing_extensions",
+    "typing_extensions;python_version<'3.10'",
 ]
 
 # Extra information


### PR DESCRIPTION
It's not used on newer Python versions.