### PR TITLE
Fix import pthonjsonlogger.jsonlogger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 build
 dist
+dist_uploaded
 *.egg-info
 
 # Tests and validation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.1](https://github.com/nhairs/python-json-logger/compare/v3.2.0...v3.2.1) - UNRELEASED
+## [3.2.1](https://github.com/nhairs/python-json-logger/compare/v3.2.0...v3.2.1) - 2024-12-16
 
 ### Fixed
 - Import error on `import pythonjsonlogger.jsonlogger` [#29](https://github.com/nhairs/python-json-logger/issues/29)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1](https://github.com/nhairs/python-json-logger/compare/v3.2.0...v3.2.1) - UNRELEASED
+
+### Fixed
+- Import error on `import pythonjsonlogger.jsonlogger` [#29](https://github.com/nhairs/python-json-logger/issues/29)
+
+
 ## [3.2.0](https://github.com/nhairs/python-json-logger/compare/v3.1.0...v3.2.0) - 2024-12-11
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-json-logger"
-version = "3.2.1.dev1"
+version = "3.2.1"
 description = "JSON Log Formatter for the Python Logging Package"
 authors = [
     {name = "Zakaria Zajac", email = "zak@madzak.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-json-logger"
-version = "3.2.0"
+version = "3.2.1.rc1"
 description = "JSON Log Formatter for the Python Logging Package"
 authors = [
     {name = "Zakaria Zajac", email = "zak@madzak.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-json-logger"
-version = "3.2.1.rc1"
+version = "3.2.1.dev1"
 description = "JSON Log Formatter for the Python Logging Package"
 authors = [
     {name = "Zakaria Zajac", email = "zak@madzak.com"},

--- a/src/pythonjsonlogger/__init__.py
+++ b/src/pythonjsonlogger/__init__.py
@@ -8,22 +8,10 @@ import warnings
 ## Installed
 
 ## Application
-import pythonjsonlogger.json
-import pythonjsonlogger.utils
+from . import json
+from . import utils
 
 ### CONSTANTS
 ### ============================================================================
-ORJSON_AVAILABLE = pythonjsonlogger.utils.package_is_available("orjson")
-MSGSPEC_AVAILABLE = pythonjsonlogger.utils.package_is_available("msgspec")
-
-
-### DEPRECATED COMPATIBILITY
-### ============================================================================
-def __getattr__(name: str):
-    if name == "jsonlogger":
-        warnings.warn(
-            "pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json",
-            DeprecationWarning,
-        )
-        return pythonjsonlogger.json
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+ORJSON_AVAILABLE = utils.package_is_available("orjson")
+MSGSPEC_AVAILABLE = utils.package_is_available("msgspec")

--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -3,6 +3,8 @@
 It retains access to old names whilst sending deprecation warnings.
 """
 
+# pylint: disable=wrong-import-position,unused-import
+
 import warnings
 
 ## Throw warning

--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -1,0 +1,14 @@
+"""Stub module retained for compatibility.
+
+It retains access to old names whilst sending deprecation warnings.
+"""
+
+## Throw warning
+warnings.warn(
+    "pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json",
+    DeprecationWarning,
+)
+
+## Import names
+from .json import JsonFormatter, JsonEncoder
+from .core import RESERVED_ATTRS

--- a/src/pythonjsonlogger/jsonlogger.py
+++ b/src/pythonjsonlogger/jsonlogger.py
@@ -3,6 +3,8 @@
 It retains access to old names whilst sending deprecation warnings.
 """
 
+import warnings
+
 ## Throw warning
 warnings.warn(
     "pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json",

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -16,7 +16,7 @@ import pythonjsonlogger
 ### ============================================================================
 def test_jsonlogger_deprecated():
     with pytest.deprecated_call():
-        pythonjsonlogger.jsonlogger
+        import pythonjsonlogger.jsonlogger
     return
 
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 ## Standard Library
 import subprocess
+import sys
 
 ## Installed
 import pytest
@@ -38,6 +39,6 @@ def test_jsonlogger_reserved_attrs_deprecated():
     ],
 )
 def test_import(command: str):
-    output = subprocess.check_output(["python", "-c", f"{command};print('OK')"])
+    output = subprocess.check_output([sys.executable, "-c", f"{command};print('OK')"])
     assert output.strip() == b"OK"
     return

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -33,6 +33,7 @@ def test_jsonlogger_reserved_attrs_deprecated():
 @pytest.mark.parametrize(
     "command",
     [
+        "from pythonjsonlogger import jsonlogger",
         "import pythonjsonlogger.jsonlogger",
         "from pythonjsonlogger.jsonlogger import JsonFormatter",
         "from pythonjsonlogger.jsonlogger import RESERVED_ATTRS",

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 ## Standard Library
+import subprocess
 
 ## Installed
 import pytest
@@ -25,4 +26,18 @@ def test_jsonlogger_reserved_attrs_deprecated():
         # Note: We use json instead of jsonlogger as jsonlogger will also produce
         # a DeprecationWarning and we specifically want the one for RESERVED_ATTRS
         pythonjsonlogger.json.RESERVED_ATTRS
+    return
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "import pythonjsonlogger.jsonlogger",
+        "from pythonjsonlogger.jsonlogger import JsonFormatter",
+        "from pythonjsonlogger.jsonlogger import RESERVED_ATTRS",
+    ],
+)
+def test_import(command: str):
+    output = subprocess.check_output(["python", "-c", f"{command};print('OK')"])
+    assert output.strip() == b"OK"
     return


### PR DESCRIPTION
Fixes: #29

Although efforts were made for backwards compatibility using `__getattr__` in `pythonjsonlogger/__init__.py`, this only worked if you were doing `from pythonjsonlogger import jsonlogger`. When importing by the full name `import pythonjsonlogger.jsonlogger` it it would fail to locate the module file and thus not be able to produce a module spec which then of course causes the import to fail.

We get around this by actually having a module that imports the names it needs from the new locations.

### Test Plan

- Run unit tests