### PR TITLE
Add options to encode stack information into an array

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Added
+- `exc_info_as_array` and `stack_info_as_array` options are added to `pythonjsonlogger.core.BaseJsonFormatter`.
+  - If `exc_info_as_array` is True (Defualt: False), formatter encode exc_info into an array.
+  - If `stack_info_as_array` is True (Defualt: False), formatter encode stack_info into an array.
+
 ## [3.2.1](https://github.com/nhairs/python-json-logger/compare/v3.2.0...v3.2.1) - 2024-12-16
 
 ### Fixed

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -134,6 +134,8 @@ class BaseJsonFormatter(logging.Formatter):
     *New in 3.1*
 
     *Changed in 3.2*: `defaults` argument is no longer ignored.
+
+    *Added in UNRELEASED*: `exc_info_as_array` and `stack_info_as_array` options are added.
     """
 
     _style: Union[logging.PercentStyle, str]  # type: ignore[assignment]

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -375,7 +375,7 @@ class BaseJsonFormatter(logging.Formatter):
         """
         return log_record
 
-    def formatException(self, ei) -> Union[str, list[str]]:
+    def formatException(self, ei) -> Union[str, list[str]]: #type: ignore
         """Format and return the specified exception information.
 
         If exc_info_as_array is set to True, This method returns an array of strings.
@@ -383,7 +383,7 @@ class BaseJsonFormatter(logging.Formatter):
         exception_info_str = super().formatException(ei)
         return exception_info_str.splitlines() if self.exc_info_as_array else exception_info_str
 
-    def formatStack(self, stack_info) -> Union[str, list[str]]:
+    def formatStack(self, stack_info) -> Union[str, list[str]]: #type: ignore
         """Format and return the specified stack information.
 
         If stack_info_as_array is set to True, This method returns an array of strings.

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -253,16 +253,10 @@ class BaseJsonFormatter(logging.Formatter):
         if not message_dict.get("exc_info") and record.exc_text:
             message_dict["exc_info"] = record.exc_text
 
-        if self.exc_info_as_array and message_dict.get("exc_info"):
-            message_dict["exc_info"] = message_dict["exc_info"].splitlines()
-
         # Display formatted record of stack frames
         # default format is a string returned from :func:`traceback.print_stack`
         if record.stack_info and not message_dict.get("stack_info"):
             message_dict["stack_info"] = self.formatStack(record.stack_info)
-
-        if self.stack_info_as_array and message_dict.get("stack_info"):
-            message_dict["stack_info"] = message_dict["stack_info"].splitlines()
 
         log_record: LogRecord = {}
         self.add_fields(log_record, record, message_dict)
@@ -380,3 +374,23 @@ class BaseJsonFormatter(logging.Formatter):
             log_record: incoming data
         """
         return log_record
+
+    def formatException(self, ei) -> Union[str, list[str]]:
+        """Format and return the specified exception information.
+
+        If exc_info_as_array is set to True, This method returns an array of strings.
+        """
+        exception_info_str = super().formatException(ei)
+        return exception_info_str.splitlines() if self.exc_info_as_array else exception_info_str
+
+    def formatStack(self, stack_info) -> Union[str, list[str]]:
+        """Format and return the specified stack information.
+
+        If stack_info_as_array is set to True, This method returns an array of strings.
+        """
+        stack_info_str = super().formatStack(stack_info)
+        return (
+            stack_info_str.splitlines()
+            if self.stack_info_as_array
+            else stack_info_str.formatStack(stack_info)
+        )

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -392,5 +392,5 @@ class BaseJsonFormatter(logging.Formatter):
         return (
             stack_info_str.splitlines()
             if self.stack_info_as_array
-            else stack_info_str.formatStack(stack_info)
+            else stack_info_str
         )

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -377,7 +377,7 @@ class BaseJsonFormatter(logging.Formatter):
         """
         return log_record
 
-    def formatException(self, ei) -> Union[str, list[str]]: #type: ignore
+    def formatException(self, ei) -> Union[str, list[str]]:  # type: ignore
         """Format and return the specified exception information.
 
         If exc_info_as_array is set to True, This method returns an array of strings.
@@ -385,14 +385,10 @@ class BaseJsonFormatter(logging.Formatter):
         exception_info_str = super().formatException(ei)
         return exception_info_str.splitlines() if self.exc_info_as_array else exception_info_str
 
-    def formatStack(self, stack_info) -> Union[str, list[str]]: #type: ignore
+    def formatStack(self, stack_info) -> Union[str, list[str]]:  # type: ignore
         """Format and return the specified stack information.
 
         If stack_info_as_array is set to True, This method returns an array of strings.
         """
         stack_info_str = super().formatStack(stack_info)
-        return (
-            stack_info_str.splitlines()
-            if self.stack_info_as_array
-            else stack_info_str
-        )
+        return stack_info_str.splitlines() if self.stack_info_as_array else stack_info_str

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -643,7 +643,7 @@ def test_exc_info_as_array_no_exc_info(env: LoggingEnvironment, class_: type[Bas
     env.logger.info("hello")
     log_json = env.load_json()
 
-    assert log_json.get("exc_info") is None
+    assert "exc_info" not in log_json
     return
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -632,7 +632,7 @@ def test_exc_info_as_array(env: LoggingEnvironment, class_: type[BaseJsonFormatt
         env.logger.exception("Error occurs")
     log_json = env.load_json()
 
-    assert type(log_json["exc_info"]) is list
+    assert isinstance(log_json["exc_info"], list)
     return
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -654,7 +654,7 @@ def test_stack_info_as_array(env: LoggingEnvironment, class_: type[BaseJsonForma
     env.logger.info("hello", stack_info=True)
     log_json = env.load_json()
 
-    assert type(log_json["stack_info"]) is list
+    assert isinstance(log_json["stack_info"], list)
     return
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -622,6 +622,55 @@ def test_custom_default(env: LoggingEnvironment, class_: type[BaseJsonFormatter]
     return
 
 
+@pytest.mark.parametrize("class_", ALL_FORMATTERS)
+def test_exc_info_as_array(env: LoggingEnvironment, class_: type[BaseJsonFormatter]):
+    env.set_formatter(class_(exc_info_as_array=True))
+
+    try:
+        raise Exception("Error")
+    except BaseException:
+        env.logger.exception("Error occurs")
+    log_json = env.load_json()
+
+    assert type(log_json["exc_info"]) is list
+    return
+
+
+@pytest.mark.parametrize("class_", ALL_FORMATTERS)
+def test_exc_info_as_array_no_exc_info(env: LoggingEnvironment, class_: type[BaseJsonFormatter]):
+    env.set_formatter(class_(exc_info_as_array=True))
+
+    env.logger.info("hello")
+    log_json = env.load_json()
+
+    assert log_json.get("exc_info") is None
+    return
+
+
+@pytest.mark.parametrize("class_", ALL_FORMATTERS)
+def test_stack_info_as_array(env: LoggingEnvironment, class_: type[BaseJsonFormatter]):
+    env.set_formatter(class_(stack_info_as_array=True))
+
+    env.logger.info("hello", stack_info=True)
+    log_json = env.load_json()
+
+    assert type(log_json["stack_info"]) is list
+    return
+
+
+@pytest.mark.parametrize("class_", ALL_FORMATTERS)
+def test_stack_info_as_array_no_stack_info(
+    env: LoggingEnvironment, class_: type[BaseJsonFormatter]
+):
+    env.set_formatter(class_(stack_info_as_array=True))
+
+    env.logger.info("hello", stack_info=False)
+    log_json = env.load_json()
+
+    assert log_json.get("stack_info") is None
+    return
+
+
 ## JsonFormatter Specific
 ## -----------------------------------------------------------------------------
 def test_json_ensure_ascii_true(env: LoggingEnvironment):

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -667,7 +667,7 @@ def test_stack_info_as_array_no_stack_info(
     env.logger.info("hello", stack_info=False)
     log_json = env.load_json()
 
-    assert log_json.get("stack_info") is None
+    assert "stack_info" not in log_json
     return
 
 


### PR DESCRIPTION
close #35 

This PR add options to encode stack information into an array.
- If `exc_info_as_array` is True (Defualt: False), formatter encode `exc_info` into an array.
- If `stack_info_as_array` is True (Defualt: False), formatter encode `stack_info` into an array.

# Checks 
All tests are passed (including new test cases). 
```
(python-json-logger) python-json-logger > black src tests
All done! ✨ 🍰 ✨
13 files left unchanged.
(python-json-logger) python-json-logger > pylint --output-format=colorized src

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

(python-json-logger) python-json-logger > mypy src tests
Success: no issues found in 13 source files
(python-json-logger) python-json-logger > pytest
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/hakusai/src/python-json-logger
configfile: pyproject.toml
collected 181 items                                                                                                                                                       

tests/test_deprecation.py ......                                                                                                                                    [  3%]
tests/test_formatters.py ..............................................................................................................................x........... [ 79%]
x..x........x....................                                                                                                                                   [ 97%]
tests/test_missing.py ....                                                                                                                                          [100%]

===================================================================== 177 passed, 4 xfailed in 0.22s ======================================================================

```