### PR TITLE
Fix license deprecation warning in pyproject.toml (#49)fix: replace table license with SPDX in pyproject.toml (#49)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ dependencies = [
 
 # Extra information
 readme = "README.md"
-license = {text = "BSD-2-Clause License"}
+license = "BSD-2-Clause"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
## Summary
This PR corrects the SetuptoolsDeprecationWarning warning reported in issue #49 :
> `project.license` as a TOML table is deprecated…

## Why
As of PEP 639 (early 2025), Python packaging moved to a clearer, unambiguous license metadata format:  
- **Before**: license declared as a TOML table with keys like `text` and `file`, which was inconsistent and hard for tools to validate.  
- **After**: a single SPDX expression string (`license = "BSD-2-Clause"`) plus a `license-files` list.  
Setuptools ≥ 77 now **requires** this new format and will warn (or error) on the old table style. This change ensures compatibility with the current Python packaging ecosystem and automatic license validation.

## Changes made
- Removed `license = { ... }` table from `[project]`.
- Added `license = "BSD-2-Clause"` and `license-files = ["LICENSE"]` in `[project]`.
- Removal of classifier `"License :: OSI Approved :: BSD License"` (compliant with PEP 639)

## How to test
1. Clone the repository and switch to this branch
2. Install a virtual environment: `python -m venv env` and `source env/bin/activate` (on Linux).
3. Install in dev: `pip install -e .[dev]`
4. Builder: `python -m build` → no more warnings or errors
5. Run the test suite: `env/bin/python -m pytest` → everything goes green

## Linked to
Closes #49