### PR TITLE
[core,json,orjson,msgspec] Remove use of str_to_object

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [4.0.0](https://github.com/nhairs/python-json-logger/compare/v3.3.3...v4.0.0) - UNRELEASED
 
 ### Added
 - Support `DictConfigurator` prefixes for `rename_fields` and `static_fields`. [#45](https://github.com/nhairs/python-json-logger/pull/45)
   - Allows using values like `ext://sys.stderr` in `fileConfig`/`dictConfig` value fields.
+
+### Removed
+- Remove support for providing strings instead of objects when instantiating formatters. Instead use the `DictConfigurator` `ext://` prefix format when using `fileConfig`/`dictConfig`. [#47](https://github.com/nhairs/python-json-logger/issues/47)
+    - Affects `pythonjsonlogger.json.JsonFormatter`: `json_default`, `json_encoder`, `json_serializer`.
+    - Affects `pythonjsonlogger.orjson.OrjsonFormatter`: `json_default`.
+    - Affects `pythonjsonlogger.msgspec.MsgspecFormatter`: `json_default`.
 
 Thanks @rubensa
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -179,7 +179,7 @@ loggers:
     propagate: no
 ```
 
-You'll notice that we are using `ext://...` for the `static_fields`. This will load data from other modules such as the one below.
+You'll notice that we are using `ext://...` for `json_default` and`static_fields`. This will load data from other modules such as the one below.
 
 ```python title="logging_config.py"
 import importlib.metadata

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -148,6 +148,7 @@ formatters:
   default:
     "()": pythonjsonlogger.json.JsonFormatter
     format: "%(asctime)s %(levelname)s %(name)s %(module)s %(funcName)s %(lineno)s %(message)s"
+    json_default: ext://logging_config.my_json_default
     rename_fields:
       "asctime": "timestamp"
       "levelname": "status"
@@ -183,6 +184,16 @@ You'll notice that we are using `ext://...` for the `static_fields`. This will l
 ```python title="logging_config.py"
 import importlib.metadata
 import os
+
+
+class Dummy:
+    pass
+
+
+def my_json_default(obj: Any) -> Any:
+    if isinstance(obj, Dummy):
+        return "DUMMY"
+    return obj
 
 
 def get_version_metadata():

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -7,11 +7,10 @@ from __future__ import annotations
 
 ## Standard Library
 from datetime import datetime, timezone
-import importlib
 import logging
 import re
 import sys
-from typing import Optional, Union, Callable, List, Dict, Container, Any, Sequence
+from typing import Optional, Union, List, Dict, Container, Any, Sequence
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -72,31 +71,12 @@ STYLE_PERCENT_REGEX = re.compile(r"%\((.+?)\)", re.IGNORECASE)  # % style
 
 ## Type Aliases
 ## -----------------------------------------------------------------------------
-OptionalCallableOrStr: TypeAlias = Optional[Union[Callable, str]]
-"""Type alias"""
-
 LogRecord: TypeAlias = Dict[str, Any]
 """Type alias"""
 
 
 ### FUNCTIONS
 ### ============================================================================
-def str_to_object(obj: Any) -> Any:
-    """Import strings to an object, leaving non-strings as-is.
-
-    Args:
-        obj: the object or string to process
-
-    *New in 3.1*
-    """
-
-    if not isinstance(obj, str):
-        return obj
-
-    module_name, attribute_name = obj.rsplit(".", 1)
-    return getattr(importlib.import_module(module_name), attribute_name)
-
-
 def merge_record_extra(
     record: logging.LogRecord,
     target: Dict,

--- a/src/pythonjsonlogger/json.py
+++ b/src/pythonjsonlogger/json.py
@@ -67,9 +67,9 @@ class JsonFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = None,
-        json_encoder: core.OptionalCallableOrStr = None,
-        json_serializer: Union[Callable, str] = json.dumps,
+        json_default: Optional[Callable] = None,
+        json_encoder: Optional[Callable] = None,
+        json_serializer: Callable = json.dumps,
         json_indent: Optional[Union[int, str]] = None,
         json_ensure_ascii: bool = True,
         **kwargs,
@@ -87,9 +87,9 @@ class JsonFormatter(core.BaseJsonFormatter):
         """
         super().__init__(*args, **kwargs)
 
-        self.json_default = core.str_to_object(json_default)
-        self.json_encoder = core.str_to_object(json_encoder)
-        self.json_serializer = core.str_to_object(json_serializer)
+        self.json_default = json_default
+        self.json_encoder = json_encoder
+        self.json_serializer = json_serializer
         self.json_indent = json_indent
         self.json_ensure_ascii = json_ensure_ascii
         if not self.json_encoder and not self.json_default:

--- a/src/pythonjsonlogger/msgspec.py
+++ b/src/pythonjsonlogger/msgspec.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 ## Standard Library
-from typing import Any
+from typing import Any, Optional, Callable
 
 ## Installed
 
@@ -43,7 +43,7 @@ class MsgspecFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = msgspec_default,
+        json_default: Optional[Callable] = msgspec_default,
         **kwargs,
     ) -> None:
         """
@@ -54,7 +54,7 @@ class MsgspecFormatter(core.BaseJsonFormatter):
         """
         super().__init__(*args, **kwargs)
 
-        self.json_default = core.str_to_object(json_default)
+        self.json_default = json_default
         self._encoder = msgspec.json.Encoder(enc_hook=self.json_default)
         return
 

--- a/src/pythonjsonlogger/orjson.py
+++ b/src/pythonjsonlogger/orjson.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 ## Standard Library
-from typing import Any
+from typing import Any, Optional, Callable
 
 ## Installed
 
@@ -45,7 +45,7 @@ class OrjsonFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = orjson_default,
+        json_default: Optional[Callable] = orjson_default,
         json_indent: bool = False,
         **kwargs,
     ) -> None:
@@ -58,7 +58,7 @@ class OrjsonFormatter(core.BaseJsonFormatter):
         """
         super().__init__(*args, **kwargs)
 
-        self.json_default = core.str_to_object(json_default)
+        self.json_default = json_default
         self.json_indent = json_indent
         return
 


### PR DESCRIPTION
Fixes: #47

Remove support for providing strings instead of objects when instantiating formatters.

Users of `fileConfig`/`dictConfig` will need to use the `DictConfigurator` `ext://` prefix format instead.

### Test Plan
- Unit tests