### PR TITLE
[core] Rename LogRecord/log_record to LogData/log_data 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `DictConfigurator` prefixes for `rename_fields` and `static_fields`. [#45](https://github.com/nhairs/python-json-logger/pull/45)
   - Allows using values like `ext://sys.stderr` in `fileConfig`/`dictConfig` value fields.
 
+### Changed
+- Rename `pythonjsonlogger.core.LogRecord` and `log_record` arguemtns to avoid confusion / overlapping with `logging.LogRecord`. [#38](https://github.com/nhairs/python-json-logger/issues/38)
+    - Affects arguments to `pythonjsonlogger.core.BaseJsonFormatter` (and any child classes).
+        - `serialize_log_record`
+        - `add_fields`
+        - `jsonify_log_record`
+        - `process_log_record`
+    - Note: functions referring to `log_record` have **not** had their function name changed.
+
 ### Removed
 - Remove support for providing strings instead of objects when instantiating formatters. Instead use the `DictConfigurator` `ext://` prefix format when using `fileConfig`/`dictConfig`. [#47](https://github.com/nhairs/python-json-logger/issues/47)
     - Affects `pythonjsonlogger.json.JsonFormatter`: `json_default`, `json_encoder`, `json_serializer`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [4.0.0](https://github.com/nhairs/python-json-logger/compare/v3.3.3...v4.0.0) - UNRELEASED
 
 ### Added
 - Support `DictConfigurator` prefixes for `rename_fields` and `static_fields`. [#45](https://github.com/nhairs/python-json-logger/pull/45)
   - Allows using values like `ext://sys.stderr` in `fileConfig`/`dictConfig` value fields.
+
+### Removed
+- Remove support for providing strings instead of objects when instantiating formatters. Instead use the `DictConfigurator` `ext://` prefix format when using `fileConfig`/`dictConfig`. [#47](https://github.com/nhairs/python-json-logger/issues/47)
+    - Affects `pythonjsonlogger.json.JsonFormatter`: `json_default`, `json_encoder`, `json_serializer`.
+    - Affects `pythonjsonlogger.orjson.OrjsonFormatter`: `json_default`.
+    - Affects `pythonjsonlogger.msgspec.MsgspecFormatter`: `json_default`.
 
 Thanks @rubensa
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Allows using values like `ext://sys.stderr` in `fileConfig`/`dictConfig` value fields.
 
 ### Changed
-- Rename `pythonjsonlogger.core.LogRecord` and `log_record` arguemtns to avoid confusion / overlapping with `logging.LogRecord`. [#38](https://github.com/nhairs/python-json-logger/issues/38)
+- Rename `pythonjsonlogger.core.LogRecord` and `log_record` arguments to avoid confusion / overlapping with `logging.LogRecord`. [#38](https://github.com/nhairs/python-json-logger/issues/38)
     - Affects arguments to `pythonjsonlogger.core.BaseJsonFormatter` (and any child classes).
         - `serialize_log_record`
         - `add_fields`

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -179,7 +179,7 @@ loggers:
     propagate: no
 ```
 
-You'll notice that we are using `ext://...` for the `static_fields`. This will load data from other modules such as the one below.
+You'll notice that we are using `ext://...` for `json_default` and`static_fields`. This will load data from other modules such as the one below.
 
 ```python title="logging_config.py"
 import importlib.metadata

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -32,8 +32,8 @@ You can modify the `dict` of data that will be logged by overriding the `process
 
 ```python
 class SillyFormatter(JsonFormatter):
-    def process_log_record(log_record):
-        new_record = {k[::-1]: v for k, v in log_record.items()}
+    def process_log_record(log_data):
+        new_record = {k[::-1]: v for k, v in log_data.items()}
         return new_record
 ```
 
@@ -119,9 +119,9 @@ Another method would be to create a custom formatter class and override the `pro
 ## -----------------------------------------------------------------------------
 # Reuse REQUEST_ID stuff from solution 2
 class MyFormatter(JsonFormatter):
-    def process_log_record(self, log_record):
-        log_record["request_id"] = get_request_id()
-        return log_record
+    def process_log_record(self, log_data):
+        log_data["request_id"] = get_request_id()
+        return log_data
 
 handler.setFormatter(MyFormatter())
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -148,6 +148,7 @@ formatters:
   default:
     "()": pythonjsonlogger.json.JsonFormatter
     format: "%(asctime)s %(levelname)s %(name)s %(module)s %(funcName)s %(lineno)s %(message)s"
+    json_default: ext://logging_config.my_json_default
     rename_fields:
       "asctime": "timestamp"
       "levelname": "status"
@@ -183,6 +184,16 @@ You'll notice that we are using `ext://...` for the `static_fields`. This will l
 ```python title="logging_config.py"
 import importlib.metadata
 import os
+
+
+class Dummy:
+    pass
+
+
+def my_json_default(obj: Any) -> Any:
+    if isinstance(obj, Dummy):
+        return "DUMMY"
+    return obj
 
 
 def get_version_metadata():

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -7,11 +7,10 @@ from __future__ import annotations
 
 ## Standard Library
 from datetime import datetime, timezone
-import importlib
 import logging
 import re
 import sys
-from typing import Optional, Union, Callable, List, Dict, Container, Any, Sequence
+from typing import Optional, Union, List, Dict, Container, Any, Sequence
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -72,31 +71,12 @@ STYLE_PERCENT_REGEX = re.compile(r"%\((.+?)\)", re.IGNORECASE)  # % style
 
 ## Type Aliases
 ## -----------------------------------------------------------------------------
-OptionalCallableOrStr: TypeAlias = Optional[Union[Callable, str]]
-"""Type alias"""
-
 LogRecord: TypeAlias = Dict[str, Any]
 """Type alias"""
 
 
 ### FUNCTIONS
 ### ============================================================================
-def str_to_object(obj: Any) -> Any:
-    """Import strings to an object, leaving non-strings as-is.
-
-    Args:
-        obj: the object or string to process
-
-    *New in 3.1*
-    """
-
-    if not isinstance(obj, str):
-        return obj
-
-    module_name, attribute_name = obj.rsplit(".", 1)
-    return getattr(importlib.import_module(module_name), attribute_name)
-
-
 def merge_record_extra(
     record: logging.LogRecord,
     target: Dict,

--- a/src/pythonjsonlogger/json.py
+++ b/src/pythonjsonlogger/json.py
@@ -67,9 +67,9 @@ class JsonFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = None,
-        json_encoder: core.OptionalCallableOrStr = None,
-        json_serializer: Union[Callable, str] = json.dumps,
+        json_default: Optional[Callable] = None,
+        json_encoder: Optional[Callable] = None,
+        json_serializer: Callable = json.dumps,
         json_indent: Optional[Union[int, str]] = None,
         json_ensure_ascii: bool = True,
         **kwargs,
@@ -87,9 +87,9 @@ class JsonFormatter(core.BaseJsonFormatter):
         """
         super().__init__(*args, **kwargs)
 
-        self.json_default = core.str_to_object(json_default)
-        self.json_encoder = core.str_to_object(json_encoder)
-        self.json_serializer = core.str_to_object(json_serializer)
+        self.json_default = json_default
+        self.json_encoder = json_encoder
+        self.json_serializer = json_serializer
         self.json_indent = json_indent
         self.json_ensure_ascii = json_ensure_ascii
         if not self.json_encoder and not self.json_default:

--- a/src/pythonjsonlogger/json.py
+++ b/src/pythonjsonlogger/json.py
@@ -96,10 +96,10 @@ class JsonFormatter(core.BaseJsonFormatter):
             self.json_encoder = JsonEncoder
         return
 
-    def jsonify_log_record(self, log_record: core.LogRecord) -> str:
-        """Returns a json string of the log record."""
+    def jsonify_log_record(self, log_data: core.LogData) -> str:
+        """Returns a json string of the log data."""
         return self.json_serializer(
-            log_record,
+            log_data,
             default=self.json_default,
             cls=self.json_encoder,
             indent=self.json_indent,

--- a/src/pythonjsonlogger/msgspec.py
+++ b/src/pythonjsonlogger/msgspec.py
@@ -58,6 +58,6 @@ class MsgspecFormatter(core.BaseJsonFormatter):
         self._encoder = msgspec.json.Encoder(enc_hook=self.json_default)
         return
 
-    def jsonify_log_record(self, log_record: core.LogRecord) -> str:
-        """Returns a json string of the log record."""
-        return self._encoder.encode(log_record).decode("utf8")
+    def jsonify_log_record(self, log_data: core.LogData) -> str:
+        """Returns a json string of the log data."""
+        return self._encoder.encode(log_data).decode("utf8")

--- a/src/pythonjsonlogger/msgspec.py
+++ b/src/pythonjsonlogger/msgspec.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 ## Standard Library
-from typing import Any
+from typing import Any, Optional, Callable
 
 ## Installed
 
@@ -43,7 +43,7 @@ class MsgspecFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = msgspec_default,
+        json_default: Optional[Callable] = msgspec_default,
         **kwargs,
     ) -> None:
         """
@@ -54,7 +54,7 @@ class MsgspecFormatter(core.BaseJsonFormatter):
         """
         super().__init__(*args, **kwargs)
 
-        self.json_default = core.str_to_object(json_default)
+        self.json_default = json_default
         self._encoder = msgspec.json.Encoder(enc_hook=self.json_default)
         return
 

--- a/src/pythonjsonlogger/orjson.py
+++ b/src/pythonjsonlogger/orjson.py
@@ -62,10 +62,10 @@ class OrjsonFormatter(core.BaseJsonFormatter):
         self.json_indent = json_indent
         return
 
-    def jsonify_log_record(self, log_record: core.LogRecord) -> str:
-        """Returns a json string of the log record."""
+    def jsonify_log_record(self, log_data: core.LogData) -> str:
+        """Returns a json string of the log data."""
         opt = orjson.OPT_NON_STR_KEYS
         if self.json_indent:
             opt |= orjson.OPT_INDENT_2
 
-        return orjson.dumps(log_record, default=self.json_default, option=opt).decode("utf8")
+        return orjson.dumps(log_data, default=self.json_default, option=opt).decode("utf8")

--- a/src/pythonjsonlogger/orjson.py
+++ b/src/pythonjsonlogger/orjson.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 ## Standard Library
-from typing import Any
+from typing import Any, Optional, Callable
 
 ## Installed
 
@@ -45,7 +45,7 @@ class OrjsonFormatter(core.BaseJsonFormatter):
     def __init__(
         self,
         *args,
-        json_default: core.OptionalCallableOrStr = orjson_default,
+        json_default: Optional[Callable] = orjson_default,
         json_indent: bool = False,
         **kwargs,
     ) -> None:
@@ -58,7 +58,7 @@ class OrjsonFormatter(core.BaseJsonFormatter):
         """
         super().__init__(*args, **kwargs)
 
-        self.json_default = core.str_to_object(json_default)
+        self.json_default = json_default
         self.json_indent = json_indent
         return
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -380,9 +380,9 @@ def test_log_extra(env: LoggingEnvironment, class_: type[BaseJsonFormatter]):
 def test_custom_logic_adds_field(env: LoggingEnvironment, class_: type[BaseJsonFormatter]):
     class CustomJsonFormatter(class_):  # type: ignore[valid-type,misc]
 
-        def process_log_record(self, log_record):
-            log_record["custom"] = "value"
-            return super().process_log_record(log_record)
+        def process_log_record(self, log_data):
+            log_data["custom"] = "value"
+            return super().process_log_record(log_data)
 
     env.set_formatter(CustomJsonFormatter())
     env.logger.info("message")


### PR DESCRIPTION
Fixes #38 

Rename `pythonjsonlogger.core.LogRecord` and `log_record` arguemtns to avoid confusion / overlapping with `logging.LogRecord`.

### Test Plan
- Linting
- Unit Tests