### PR TITLE
[docs] Fix typo in quickstart: exluded

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ formatter = JsonFormatter(
 
 ### Excluding fields
 
-You can prevent fields being added to the output data by adding them to `reserved_attrs`. By default all [`LogRecord` attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) are exluded.
+You can prevent fields being added to the output data by adding them to `reserved_attrs`. By default all [`LogRecord` attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) are excluded.
 
 ```python
 from pythonjsonlogger.core import RESERVED_ATTRS


### PR DESCRIPTION
Thank you for developing this awesome library!

I found a typo, so sent this pull request:
https://nhairs.github.io/python-json-logger/latest/quickstart/#excluding-fields

>By default all LogRecord attributes are exluded.

```
$ git grep exlude
docs/quickstart.md:You can prevent fields being added to the output data by adding them to `reserved_attrs`. By default all [`LogRecord` attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) are exluded.
```