### PR TITLE
Fix tox build failure under PyPy 3.10 by conditionally pinning mypy<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dev = [
     "validate-pyproject[all]",
     "black",
     "pylint",
-    "mypy",
+    "mypy<2; implementation_name == 'pypy' and python_version < '3.11'",
+    "mypy; implementation_name != 'pypy' or python_version >= '3.11'",
     ## Test
     "pytest",
     "freezegun",


### PR DESCRIPTION
Conditional pinning of mypy to <2 under PyPy with Python version lower than 3.11. This prevents the build of ast-serialize from failing on PyPy 3.10 due to PyO3 version requirements.

---
*PR created automatically by Jules for task [13477247122132504468](https://jules.google.com/task/13477247122132504468) started by @nhairs*