### PR TITLE
[core] support unbraced $name fields in $ style formats

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Logging a `dict` no longer modifies it. `exc_info` and `stack_info` were previously added to the caller's `dict`. [#66](https://github.com/nhairs/python-json-logger/pull/66)
+- `$` style formats now support unbraced `$name` fields, not just `${name}`. [#18](https://github.com/nhairs/python-json-logger/issues/18)
 
 Thanks @gaoflow, @prateek-dagar
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logging a `dict` no longer modifies it. `exc_info` and `stack_info` were previously added to the caller's `dict`. [#66](https://github.com/nhairs/python-json-logger/pull/66)
 - `$` style formats now support unbraced `$name` fields, not just `${name}`. [#18](https://github.com/nhairs/python-json-logger/issues/18)
 
-Thanks @gaoflow, @prateek-dagar
+Thanks @gaoflow, @prateek-dagar, @Sanjays2402
 
 ## [4.1.0](https://github.com/nhairs/python-json-logger/compare/v4.0.0...v4.1.0) - 2026-03-29
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Logging a `dict` no longer modifies it. `exc_info` and `stack_info` were previously added to the caller's `dict`. [#66](https://github.com/nhairs/python-json-logger/pull/66)
+- `$` style formats now support unbraced `$name` fields, not just `${name}`. [#18](https://github.com/nhairs/python-json-logger/issues/18)
 
 Thanks @gaoflow
 

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -61,7 +61,9 @@ if sys.version_info >= (3, 12):
     RESERVED_ATTRS.sort()
 
 
-STYLE_STRING_TEMPLATE_REGEX = re.compile(r"\$\{(.+?)\}", re.IGNORECASE)  # $ style
+STYLE_STRING_TEMPLATE_REGEX = re.compile(
+    r"\$(?:\$|\{(?P<braced>.+?)\}|(?P<named>[_a-z][_a-z0-9]*))", re.IGNORECASE
+)  # $ style
 STYLE_STRING_FORMAT_REGEX = re.compile(r"\{(.+?)\}", re.IGNORECASE)  # { style
 STYLE_PERCENT_REGEX = re.compile(r"%\((.+?)\)", re.IGNORECASE)  # % style
 
@@ -302,7 +304,12 @@ class BaseJsonFormatter(logging.Formatter):
             raise ValueError(f"Style {self._style!r} is not supported")
 
         if isinstance(self._style, logging.StringTemplateStyle):
-            formatter_style_pattern = STYLE_STRING_TEMPLATE_REGEX
+            # String templates support both ${name} and $name, and $$ is an escaped literal
+            return [
+                match.group("braced") or match.group("named")
+                for match in STYLE_STRING_TEMPLATE_REGEX.finditer(self._fmt)
+                if match.group("braced") or match.group("named")
+            ]
 
         elif isinstance(self._style, logging.StrFormatStyle):
             formatter_style_pattern = STYLE_STRING_FORMAT_REGEX

--- a/src/pythonjsonlogger/core.py
+++ b/src/pythonjsonlogger/core.py
@@ -311,18 +311,15 @@ class BaseJsonFormatter(logging.Formatter):
                 if match.group("braced") or match.group("named")
             ]
 
-        elif isinstance(self._style, logging.StrFormatStyle):
-            formatter_style_pattern = STYLE_STRING_FORMAT_REGEX
+        if isinstance(self._style, logging.StrFormatStyle):
+            return STYLE_STRING_FORMAT_REGEX.findall(self._fmt)
 
-        elif isinstance(self._style, logging.PercentStyle):
+        if isinstance(self._style, logging.PercentStyle):
             # PercentStyle is parent class of StringTemplateStyle and StrFormatStyle
             # so it must be checked last.
-            formatter_style_pattern = STYLE_PERCENT_REGEX
+            return STYLE_PERCENT_REGEX.findall(self._fmt)
 
-        else:
-            raise ValueError(f"Style {self._style!r} is not supported")
-
-        return formatter_style_pattern.findall(self._fmt)
+        raise ValueError(f"Style {self._style!r} is not supported")
 
     def serialize_log_record(self, log_data: LogData) -> str:
         """Returns the final representation of the data to be logged

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -168,6 +168,22 @@ def test_percentage_format(env: LoggingEnvironment, class_: type[BaseJsonFormatt
 
 
 @pytest.mark.parametrize("class_", ALL_FORMATTERS)
+def test_string_template_format(env: LoggingEnvironment, class_: type[BaseJsonFormatter]):
+    # Note: string templates support both $name and ${name}, and $$ is an escaped literal $
+    env.set_formatter(
+        class_("$$literal $levelname ${message} $filename ${lineno} $asctime", style="$")
+    )
+
+    msg = "testing logging format"
+    env.logger.info(msg)
+    log_json = env.load_json()
+
+    assert log_json["message"] == msg
+    assert log_json.keys() == {"levelname", "message", "filename", "lineno", "asctime"}
+    return
+
+
+@pytest.mark.parametrize("class_", ALL_FORMATTERS)
 def test_comma_format(env: LoggingEnvironment, class_: type[BaseJsonFormatter]):
     # Note: we have double comma `,,` to test handling "empty" names
     env.set_formatter(class_("levelname,,message,filename,lineno,asctime,", style=","))


### PR DESCRIPTION
Closes #18

`parse()` matched only `${name}` for `StringTemplateStyle`, so a `$`-style format like `"$asctime $levelname $message"` returned no fields at all and the emitted JSON was missing every requested attribute. `string.Template` accepts both `$name` and `${name}`, so the regex now matches both and skips the `$$` escape.

New `test_string_template_format` sits beside `test_percentage_format`/`test_comma_format` in `tests/test_formatters.py` and covers both forms plus `$$`; it fails on the current regex and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
