### PR TITLE
Move development dependencies to dependency-groups (PEP 735)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Logging a `dict` no longer modifies it. `exc_info` and `stack_info` were previously added to the caller's `dict`. [#66](https://github.com/nhairs/python-json-logger/pull/66)
 
-Thanks @gaoflow
+Thanks @gaoflow, @prateek-dagar
 
 ## [4.1.0](https://github.com/nhairs/python-json-logger/compare/v4.0.0...v4.1.0) - 2026-03-29
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.2.0](https://github.com/nhairs/python-json-logger/compare/v4.1.0...v4.2.0) - UNRELEASED
 
+### Changed
+- Move development dependencies from `project.optional-dependencies.dev` to `[dependency-groups].dev` (PEP 735). [#46](https://github.com/nhairs/python-json-logger/issues/46)
+
 ### Fixed
 - Logging a `dict` no longer modifies it. `exc_info` and `stack_info` were previously added to the caller's `dict`. [#66](https://github.com/nhairs/python-json-logger/pull/66)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,10 +33,10 @@ While the style guide covers detailed conventions, always try to match the style
 
 #### Development Setup
 
-All devlopment tooling can be installed (usually into a virtual environment), using the `dev` optional dependency:
+All development tooling can be installed (usually into a virtual environment) using `uv` with the `dev` dependency group:
 
 ```shell
-pip install -e '.[dev]'`
+uv sync --group dev
 ```
 
 Before creating your pull request you'll want to format your code and run the linters and tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 Homepage = "https://nhairs.github.io/python-json-logger"
 GitHub = "https://github.com/nhairs/python-json-logger"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     ## Optional but required for dev
     "orjson;implementation_name!='pypy'",

--- a/tox.ini
+++ b/tox.ini
@@ -4,19 +4,19 @@ envlist = py{310,311,312,313,314}, pypy{310,311}
 
 [testenv]
 description = run unit tests
-extras = dev
+dependency_groups = dev
 commands =
     pytest tests
 
 [testenv:format]
 description = run formatters
-extras = dev
+dependency_groups = dev
 commands =
     black src tests
 
 [testenv:lint]
 description = run linters
-extras = dev
+dependency_groups = dev
 commands =
     validate-pyproject pyproject.toml
     black --check --diff src tests


### PR DESCRIPTION
Closes #46.
This PR migrates the development dependencies from `project.optional-dependencies.dev` to the standardized `[dependency-groups].dev` table in `pyproject.toml`, as defined in PEP 735.

### Summary of changes
- **`pyproject.toml`**: Moved `dev` dependencies to `[dependency-groups]`.
- **`tox.ini`**: Configured environment runner to use `dependency_groups = dev` instead of `extras = dev`.
- **`docs/contributing.md`**: Updated setup instruction to `uv sync --group dev`.

### How the pull request was tested
- Ran formatters/linters using `uvx tox -e lint` (passed successfully).
- Verified unit test suite execution locally using `uv run pytest` (passed successfully).

### Checklist
- [x] Updated any relevant tests
- [x] Formatted code and ran linters and tests
- [x] Updated version suffix in `pyproject.toml` (using `4.2.0.dev1`)
- [x] Added details of the changes to the change log (`docs/changelog.md`)
- [x] Added notes for new / changed features in the relevant docstring